### PR TITLE
Upgrade to code to improve recompletion options

### DIFF
--- a/classes/recompletion_form.php
+++ b/classes/recompletion_form.php
@@ -41,16 +41,71 @@ class local_recompletion_recompletion_form extends moodleform {
         $course = $this->_customdata['course'];
 
         $mform->addElement('checkbox', 'enable', get_string('enablerecompletion', 'local_recompletion'));
+        $mform->addHelpButton('enable', 'enablerecompletion', 'local_recompletion');
 
         $options = array('optional' => false, 'defaultunit' => 86400);
         $mform->addElement('duration', 'recompletionduration', get_string('recompletionrange', 'local_recompletion'), $options);
+        $mform->addHelpButton('recompletionduration', 'recompletionrange', 'local_recompletion');
         $mform->disabledIf('recompletionduration', 'enable', 'notchecked');
+        $mform->addElement('checkbox', 'archivecompletiondata', get_string('archivecompletiondata', 'local_recompletion'));
+        $mform->addHelpButton('archivecompletiondata', 'archivecompletiondata', 'local_recompletion');
+        $mform->disabledIf('archivecompletiondata', 'enable', 'notchecked');
+
+        // Grade data deletion and archiving settings.
+        $mform->addElement('header', 'gradeheader', get_string('graderecompletiontitle', 'local_recompletion'));
+        $mform->setExpanded('gradeheader');
+        $mform->addElement('checkbox', 'deletegradedata', get_string('deletegradedata', 'local_recompletion'));
+        $mform->addHelpButton('deletegradedata', 'deletegradedata', 'local_recompletion');
+        $mform->disabledIf('deletegradedata', 'enable', 'notchecked');
+        $mform->addElement('checkbox', 'archivegradedata', get_string('archivegradedata', 'local_recompletion'));
+        $mform->addHelpButton('archivegradedata', 'archivegradedata', 'local_recompletion');
+        $mform->disabledIf('archivegradedata', 'enable', 'notchecked');
+        $mform->disabledIf('archivegradedata', 'deletegradedata', 'notchecked');
+
+        // Quiz data deletion and archiving settings.
+        $mform->addElement('header', 'quizheader', get_string('quizrecompletiontitle', 'local_recompletion'));
+        $mform->setExpanded('quizheader');
+        $mform->addElement('checkbox', 'deletequizdata', get_string('deletequizdata', 'local_recompletion'));
+        $mform->addHelpButton('deletequizdata', 'deletequizdata', 'local_recompletion');
+        $mform->disabledIf('deletequizdata', 'enable', 'notchecked');
+        $mform->addElement('checkbox', 'archivequizdata', get_string('archivequizdata', 'local_recompletion'));
+        $mform->addHelpButton('archivequizdata', 'archivequizdata', 'local_recompletion');
+        $mform->disabledIf('archivequizdata', 'enable', 'notchecked');
+        $mform->disabledIf('archivequizdata', 'deletequizdata', 'notchecked');
+
+        // Quiz data deletion and archiving settings.
+        $mform->addElement('header', 'scormheader', get_string('scormrecompletiontitle', 'local_recompletion'));
+        $mform->setExpanded('scormheader');
+        $mform->addElement('checkbox', 'deletescormdata', get_string('deletescormdata', 'local_recompletion'));
+        $mform->addHelpButton('deletescormdata', 'deletescormdata', 'local_recompletion');
+        $mform->disabledIf('deletescormdata', 'enable', 'notchecked');
+        $mform->addElement('checkbox', 'archivescormdata', get_string('archivescormdata', 'local_recompletion'));
+        $mform->addHelpButton('archivescormdata', 'archivescormdata', 'local_recompletion');
+        $mform->disabledIf('archivescormdata', 'enable', 'notchecked');
+        $mform->disabledIf('archivescormdata', 'deletescormdata', 'notchecked');
+
+        // Email Notification settings.
+        $mform->addElement('header', 'emailheader', get_string('emailrecompletiontitle', 'local_recompletion'));
+        $mform->setExpanded('emailheader');
+        $mform->addElement('checkbox', 'recompletionemailenable', get_string('recompletionemailenable', 'local_recompletion'));
+        $mform->addHelpButton('recompletionemailenable', 'recompletionemailenable', 'local_recompletion');
+        $mform->disabledIf('recompletionemailenable', 'enable', 'notchecked');
+        $mform->addElement('text', 'recompletionemailheader', get_string('recompletionemailheader', 'local_recompletion'), 'size = "80"');
+        $mform->setType('recompletionemailheader', PARAM_RAW);
+        $mform->addHelpButton('recompletionemailheader', 'recompletionemailheader', 'local_recompletion');
+        $mform->disabledIf('recompletionemailheader', 'enable', 'notchecked');
+        $mform->disabledIf('recompletionemailheader', 'recompletionemailenable', 'notchecked');
+        $options = array('cols' => '60', 'rows' => '8');
+        $mform->addElement('textarea', 'recompletionemailbody', get_string('recompletionemailbody', 'local_recompletion'), $options);
+        $mform->addHelpButton('recompletionemailbody', 'recompletionemailbody', 'local_recompletion');
+        $mform->disabledIf('recompletionemailbody', 'enable', 'notchecked');
+        $mform->disabledIf('recompletionemailbody', 'recompletionemailenable', 'notchecked');
+
         // Add common action buttons.
         $this->add_action_buttons();
 
         // Add hidden fields.
         $mform->addElement('hidden', 'course', $course->id);
         $mform->setType('course', PARAM_INT);
-
     }
 }

--- a/classes/recompletion_form.php
+++ b/classes/recompletion_form.php
@@ -47,59 +47,60 @@ class local_recompletion_recompletion_form extends moodleform {
         $mform->addElement('duration', 'recompletionduration', get_string('recompletionrange', 'local_recompletion'), $options);
         $mform->addHelpButton('recompletionduration', 'recompletionrange', 'local_recompletion');
         $mform->disabledIf('recompletionduration', 'enable', 'notchecked');
-        $mform->addElement('checkbox', 'archivecompletiondata', get_string('archivecompletiondata', 'local_recompletion'));
-        $mform->addHelpButton('archivecompletiondata', 'archivecompletiondata', 'local_recompletion');
-        $mform->disabledIf('archivecompletiondata', 'enable', 'notchecked');
-
-        // Grade data deletion and archiving settings.
-        $mform->addElement('header', 'gradeheader', get_string('graderecompletiontitle', 'local_recompletion'));
-        $mform->setExpanded('gradeheader');
-        $mform->addElement('checkbox', 'deletegradedata', get_string('deletegradedata', 'local_recompletion'));
-        $mform->addHelpButton('deletegradedata', 'deletegradedata', 'local_recompletion');
-        $mform->disabledIf('deletegradedata', 'enable', 'notchecked');
-        $mform->addElement('checkbox', 'archivegradedata', get_string('archivegradedata', 'local_recompletion'));
-        $mform->addHelpButton('archivegradedata', 'archivegradedata', 'local_recompletion');
-        $mform->disabledIf('archivegradedata', 'enable', 'notchecked');
-        $mform->disabledIf('archivegradedata', 'deletegradedata', 'notchecked');
-
-        // Quiz data deletion and archiving settings.
-        $mform->addElement('header', 'quizheader', get_string('quizrecompletiontitle', 'local_recompletion'));
-        $mform->setExpanded('quizheader');
-        $mform->addElement('checkbox', 'deletequizdata', get_string('deletequizdata', 'local_recompletion'));
-        $mform->addHelpButton('deletequizdata', 'deletequizdata', 'local_recompletion');
-        $mform->disabledIf('deletequizdata', 'enable', 'notchecked');
-        $mform->addElement('checkbox', 'archivequizdata', get_string('archivequizdata', 'local_recompletion'));
-        $mform->addHelpButton('archivequizdata', 'archivequizdata', 'local_recompletion');
-        $mform->disabledIf('archivequizdata', 'enable', 'notchecked');
-        $mform->disabledIf('archivequizdata', 'deletequizdata', 'notchecked');
-
-        // Quiz data deletion and archiving settings.
-        $mform->addElement('header', 'scormheader', get_string('scormrecompletiontitle', 'local_recompletion'));
-        $mform->setExpanded('scormheader');
-        $mform->addElement('checkbox', 'deletescormdata', get_string('deletescormdata', 'local_recompletion'));
-        $mform->addHelpButton('deletescormdata', 'deletescormdata', 'local_recompletion');
-        $mform->disabledIf('deletescormdata', 'enable', 'notchecked');
-        $mform->addElement('checkbox', 'archivescormdata', get_string('archivescormdata', 'local_recompletion'));
-        $mform->addHelpButton('archivescormdata', 'archivescormdata', 'local_recompletion');
-        $mform->disabledIf('archivescormdata', 'enable', 'notchecked');
-        $mform->disabledIf('archivescormdata', 'deletescormdata', 'notchecked');
+        $mform->addElement('checkbox', 'recompletionemailenable', get_string('recompletionemailenable', 'local_recompletion'));
+        $mform->setDefault('recompletionemailenable', 1);
+        $mform->addHelpButton('recompletionemailenable', 'recompletionemailenable', 'local_recompletion');
+        $mform->disabledIf('recompletionemailenable', 'enable', 'notchecked');
 
         // Email Notification settings.
         $mform->addElement('header', 'emailheader', get_string('emailrecompletiontitle', 'local_recompletion'));
-        $mform->setExpanded('emailheader');
-        $mform->addElement('checkbox', 'recompletionemailenable', get_string('recompletionemailenable', 'local_recompletion'));
-        $mform->addHelpButton('recompletionemailenable', 'recompletionemailenable', 'local_recompletion');
-        $mform->disabledIf('recompletionemailenable', 'enable', 'notchecked');
-        $mform->addElement('text', 'recompletionemailheader', get_string('recompletionemailheader', 'local_recompletion'), 'size = "80"');
-        $mform->setType('recompletionemailheader', PARAM_RAW);
-        $mform->addHelpButton('recompletionemailheader', 'recompletionemailheader', 'local_recompletion');
-        $mform->disabledIf('recompletionemailheader', 'enable', 'notchecked');
-        $mform->disabledIf('recompletionemailheader', 'recompletionemailenable', 'notchecked');
+        $mform->setExpanded('emailheader', false);
+        $mform->addElement('text', 'recompletionemailsubject', get_string('recompletionemailsubject', 'local_recompletion'),
+                'size = "80"');
+        $mform->setType('recompletionemailsubject', PARAM_RAW);
+        $mform->addHelpButton('recompletionemailsubject', 'recompletionemailsubject', 'local_recompletion');
+        $mform->disabledIf('recompletionemailsubject', 'enable', 'notchecked');
+        $mform->disabledIf('recompletionemailsubject', 'recompletionemailenable', 'notchecked');
         $options = array('cols' => '60', 'rows' => '8');
-        $mform->addElement('textarea', 'recompletionemailbody', get_string('recompletionemailbody', 'local_recompletion'), $options);
+        $mform->addElement('textarea', 'recompletionemailbody', get_string('recompletionemailbody', 'local_recompletion'),
+                $options);
         $mform->addHelpButton('recompletionemailbody', 'recompletionemailbody', 'local_recompletion');
         $mform->disabledIf('recompletionemailbody', 'enable', 'notchecked');
         $mform->disabledIf('recompletionemailbody', 'recompletionemailenable', 'notchecked');
+
+        // Advanced recompletion settings.
+        // Delete data section.
+        $mform->addElement('header', 'advancedheader', get_string('advancedrecompletiontitle', 'local_recompletion'));
+        $mform->setExpanded('advancedheader', false);
+        $mform->addElement('static', 'deletewhichdata', get_string('deletewhichdata', 'local_recompletion'));
+        $mform->addElement('checkbox', 'deletegradedata', get_string('deletegradedata', 'local_recompletion'));
+        $mform->setDefault('deletegradedata', 1);
+        $mform->addHelpButton('deletegradedata', 'deletegradedata', 'local_recompletion');
+        $mform->disabledIf('deletegradedata', 'enable', 'notchecked');
+        $mform->addElement('checkbox', 'deletequizdata', get_string('deletequizdata', 'local_recompletion'));
+        $mform->setDefault('deletequizdata', 1);
+        $mform->addHelpButton('deletequizdata', 'deletequizdata', 'local_recompletion');
+        $mform->disabledIf('deletequizdata', 'enable', 'notchecked');
+        $mform->addElement('checkbox', 'deletescormdata', get_string('deletescormdata', 'local_recompletion'));
+        $mform->setDefault('deletescormdata', 1);
+        $mform->addHelpButton('deletescormdata', 'deletescormdata', 'local_recompletion');
+        $mform->disabledIf('deletescormdata', 'enable', 'notchecked');
+        // Archive data section.
+        $mform->addElement('static', 'archivewhichdata', get_string('archivewhichdata', 'local_recompletion'));
+        $mform->addElement('checkbox', 'archivecompletiondata', get_string('archivecompletiondata', 'local_recompletion'));
+        $mform->setDefault('archivecompletiondata', 1);
+        $mform->addHelpButton('archivecompletiondata', 'archivecompletiondata', 'local_recompletion');
+        $mform->disabledIf('archivecompletiondata', 'enable', 'notchecked');
+        $mform->addElement('checkbox', 'archivequizdata', get_string('archivequizdata', 'local_recompletion'));
+        $mform->setDefault('archivequizdata', 1);
+        $mform->addHelpButton('archivequizdata', 'archivequizdata', 'local_recompletion');
+        $mform->disabledIf('archivequizdata', 'enable', 'notchecked');
+        $mform->disabledIf('archivequizdata', 'deletequizdata', 'notchecked');
+        $mform->addElement('checkbox', 'archivescormdata', get_string('archivescormdata', 'local_recompletion'));
+        $mform->setDefault('archivescormdata', 1);
+        $mform->addHelpButton('archivescormdata', 'archivescormdata', 'local_recompletion');
+        $mform->disabledIf('archivescormdata', 'enable', 'notchecked');
+        $mform->disabledIf('archivescormdata', 'deletescormdata', 'notchecked');
 
         // Add common action buttons.
         $this->add_action_buttons();

--- a/classes/task/check_recompletion.php
+++ b/classes/task/check_recompletion.php
@@ -55,12 +55,12 @@ class check_recompletion extends \core\task\scheduled_task {
         if (!\completion_info::is_enabled_for_site()) {
             return;
         }
-        $sql = 'SELECT cc.userid, cc.course
-                  FROM {course_completions} cc
-                  JOIN {local_recompletion} r ON r.course = cc.course AND r.enable = 1
-                  JOIN {course} c ON c.id = cc.course
-                  WHERE c.enablecompletion = '.COMPLETION_ENABLED.' AND
-                  (cc.timecompleted + r.recompletionduration) < ?';
+        $sql = 'SELECT cc.userid, cc.course, r.archivecompletiondata, r.deletegradedata, r.archivegradedata, r.deletequizdata, r.archivequizdata, r.deletescormdata, r.archivescormdata, r.recompletionemailenable, r.recompletionemailheader, r.recompletionemailbody
+            FROM {course_completions} cc
+            JOIN {local_recompletion} r ON r.course = cc.course AND r.enable = 1
+            JOIN {course} c ON c.id = cc.course
+            WHERE c.enablecompletion = '.COMPLETION_ENABLED.' AND
+            (cc.timecompleted + r.recompletionduration) < ?';
         $users = $DB->get_recordset_sql($sql, array(time()));
         $courses = array();
         $clearcache = false;
@@ -75,36 +75,108 @@ class check_recompletion extends \core\task\scheduled_task {
 
             // Archive and delete course completion.
             $params = array('userid' => $user->userid, 'course' => $user->course);
-
-            $coursecompletions = $DB->get_records('course_completions', $params);
-            $DB->insert_records('local_recompletion_cc', $coursecompletions);
+            if ($user->archivecompletiondata) {
+                $coursecompletions = $DB->get_records('course_completions', $params);
+                $DB->insert_records('local_recompletion_cc', $coursecompletions);
+                $criteriacompletions = $DB->get_records('course_completion_crit_compl', $params);
+                $DB->insert_records('local_recompletion_cc_cc', $criteriacompletions);
+            }
             $DB->delete_records('course_completions', $params);
-
-            $criteriacompletions = $DB->get_records('course_completion_crit_compl', $params);
-            $DB->insert_records('local_recompletion_cc_cc', $criteriacompletions);
             $DB->delete_records('course_completion_crit_compl', $params);
 
-            // Delete all activity completions.
+            // Archive and delete all activity completions.
             $selectsql = 'userid = ? AND coursemoduleid IN (SELECT id FROM {course_modules} WHERE course = ?)';
-            $cmc = $DB->get_records_select('course_modules_completion', $selectsql, $params);
-            $DB->insert_records('local_recompletion_cmc', $cmc);
+            if ($user->archivecompletiondata) {
+                $cmc = $DB->get_records_select('course_modules_completion', $selectsql, $params);
+                $DB->insert_records('local_recompletion_cmc', $cmc);
+            }
             $DB->delete_records_select('course_modules_completion', $selectsql, $params);
 
+            // Archive and delete current grade information.
+            if ($user->deletegradedata) {
+                $selectsql = 'userid = ? AND itemid IN (SELECT id FROM {course_modules} WHERE course = ?)';
+                if ($user->archivegradedata) {
+                    $gradegrades = $DB->get_records_select('grade_grades', $selectsql, $params);
+                    $DB->insert_records('local_recompletion_gg', $gradegrades);
+                }
+                $DB->delete_records_select('grade_grades', $selectsql, $params);
+            }
+
+            // Archive and delete quiz attempts information.
+            if ($user->deletequizdata) {
+                $selectsql = 'userid = ? AND quiz IN (SELECT id FROM {quiz} WHERE course = ?)';
+                if ($user->archivequizdata) {
+                    $quizattempts = $DB->get_records_select('quiz_attempts', $selectsql, $params);
+                    $DB->insert_records('local_recompletion_qa', $quizattempts);
+                    $quizgrades = $DB->get_records_select('quiz_grades', $selectsql, $params);
+                    $DB->insert_records('local_recompletion_qg', $quizgrades);
+                }
+                $DB->delete_records_select('quiz_attempts', $selectsql, $params);
+                $DB->delete_records_select('quiz_grades', $selectsql, $params);
+            }
+
+            // Archive and delete scorm attempts information.
+            if ($user->deletescormdata) {
+                $selectsql = 'userid = ? AND scormid IN (SELECT id FROM {scorm} WHERE course = ?)';
+                if ($user->archivescormdata) {
+                    $scormscoestrack = $DB->get_records_select('scorm_scoes_track', $selectsql, $params);
+                    $DB->insert_records('local_recompletion_sst', $scormscoestrack);
+                    $scormaiccsession = $DB->get_records_select('scorm_aicc_session', $selectsql, $params);
+                    $DB->insert_records('local_recompletion_sas', $scormaiccsession);
+                }
+                $DB->delete_records_select('scorm_scoes_track', $selectsql, $params);
+                $DB->delete_records_select('scorm_aicc_session', $selectsql, $params);
+            }
+
             // Now notify user.
-            $user = $DB->get_record('user', array('id' => $user->userid));
-            $a = new \stdClass();
-            $a->name = $course->shortname;
-            $a->link = course_get_url($course)->out();
-            $subject = get_string('recompletionemailsubject', 'local_recompletion');
-            $content = get_string('recompletionemailcontent', 'local_recompletion', $a);
-            email_to_user($user, $SITE->shortname, $subject, $content);
+            if ($user->recompletionemailenable) {
+                $userrecord = $DB->get_record('user', array('id' => $user->userid));
+                $coursedetails = $DB->get_record('course', array('id' => $user->course), '*', MUST_EXIST);
+                $context = \context_course::instance($course->id);
+                $from = get_admin();
+                $a = new \stdClass();
+                $a->coursename = format_string($coursedetails->fullname, true, array('context' => $context));
+                $a->profileurl = "$CFG->wwwroot/user/view.php?id=$userrecord->id&course=$coursedetails->id";
+                $a->link = course_get_url($course)->out();
+                if (trim($user->recompletionemailbody) !== '') {
+                    $message = $user->recompletionemailbody;
+                    $key = array('{$a->coursename}', '{$a->profileurl}', '{$a->link}', '{$a->fullname}', '{$a->email}');
+                    $value = array($a->coursename, $a->profileurl, $a->link, fullname($userrecord), $userrecord->email);
+                    $message = str_replace($key, $value, $message);
+                    if (strpos($message, '<') === false) {
+                        // Plain text only.
+                        $messagetext = $message;
+                        $messagehtml = text_to_html($messagetext, null, false, true);
+                    } else {
+                        // This is most probably the tag/newline soup known as FORMAT_MOODLE.
+                        $messagehtml = format_text($message, FORMAT_MOODLE, array('context' => $context, 'para' => false, 'newlines' => true, 'filter' => true));
+                        $messagetext = html_to_text($messagehtml);
+                    }
+                } else {
+                    $messagetext = get_string('recompletionemailcontent', 'local_recompletion', $a);
+                    $messagehtml = text_to_html($messagetext, null, false, true);
+                }
+                if (trim($user->recompletionemailheader) !== '') {
+                    $subject = $user->recompletionemailheader;
+                    $keysub = array('{$a->coursename}', '{$a->fullname}');
+                    $valuesub = array($a->coursename, fullname($userrecord));
+                    $subject = str_replace($keysub, $valuesub, $subject);
+                } else {
+                    $subject = get_string('recompletionemailsubject', 'local_recompletion', $a);
+                }
+                // Directly emailing recompletion message rather than using messaging.
+                email_to_user($userrecord, $from, $subject, $messagetext, $messagehtml);
+            }
 
             $clearcache = true;
         }
         if ($clearcache) {
             // Difficult to find affected users, just purge all completion cache.
             \cache::make('core', 'completion')->purge();
-            \cache::make('core', 'coursecompletion')->purge();
+            // Clear coursecompletion cache which was added in Moodle 3.2.
+            if ($CFG->version >= 2016120500) {
+                \cache::make('core', 'coursecompletion')->purge();
+            }
         }
     }
 }

--- a/db/install.xml
+++ b/db/install.xml
@@ -10,15 +10,14 @@
         <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Course id"/>
         <FIELD NAME="enable" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Enable recompletion for this course"/>
         <FIELD NAME="recompletionduration" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Duration for recompletion"/>
-        <FIELD NAME="archivecompletiondata" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Archive completion data for this course"/>
         <FIELD NAME="deletegradedata" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Delete current grade data for this course"/>
-        <FIELD NAME="archivegradedata" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Archive current grade data for this course"/>
         <FIELD NAME="deletequizdata" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Delete quiz data for this course"/>
-        <FIELD NAME="archivequizdata" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Archive quiz data for this course"/>
         <FIELD NAME="deletescormdata" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Delete scorm data for this course"/>
+        <FIELD NAME="archivecompletiondata" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Archive completion data for this course"/>
+        <FIELD NAME="archivequizdata" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Archive quiz data for this course"/>
         <FIELD NAME="archivescormdata" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Archive scorm data for this course"/>
         <FIELD NAME="recompletionemailenable" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Enable recompletion email message for this course"/>
-        <FIELD NAME="recompletionemailheader" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Recompletion message subject"/>
+        <FIELD NAME="recompletionemailsubject" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Recompletion message subject"/>
         <FIELD NAME="recompletionemailbody" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Recompletion message body"/>
       </FIELDS>
       <KEYS>
@@ -79,43 +78,6 @@
       </KEYS>
       <INDEXES>
         <INDEX NAME="coursemoduleid" UNIQUE="false" FIELDS="coursemoduleid" COMMENT="For quick access via course-module (e.g. when displaying course module settings page and we need to determine whether anyone has completed it)."/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="local_recompletion_gg" COMMENT="archive of grade_grades table">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="itemid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The item this grade belongs to"/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The user who this grade is for"/>
-        <FIELD NAME="rawgrade" TYPE="number" LENGTH="10" NOTNULL="false" SEQUENCE="false" DECIMALS="5" COMMENT="If the grade is a float value (or has been converted to one)"/>
-        <FIELD NAME="rawgrademax" TYPE="number" LENGTH="10" NOTNULL="true" DEFAULT="100" SEQUENCE="false" DECIMALS="5" COMMENT="The maximum allowable grade when this was created"/>
-        <FIELD NAME="rawgrademin" TYPE="number" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" DECIMALS="5" COMMENT="The minimum allowable grade when this was created"/>
-        <FIELD NAME="rawscaleid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="If this grade is based on a scale, which one was it?"/>
-        <FIELD NAME="usermodified" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="the userid of the person who last modified this grade"/>
-        <FIELD NAME="finalgrade" TYPE="number" LENGTH="10" NOTNULL="false" SEQUENCE="false" DECIMALS="5" COMMENT="The final grade (cached) after all calculations are made"/>
-        <FIELD NAME="hidden" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="show 0, hide 1 or hide until date"/>
-        <FIELD NAME="locked" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="not locked 0, locked from date"/>
-        <FIELD NAME="locktime" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="automatic locking of final grade, 0 means none, date otherwise"/>
-        <FIELD NAME="exported" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="date of last grade export, 0 if none"/>
-        <FIELD NAME="overridden" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="indicates grade overridden from gradebook, 0 means none, date means overridden"/>
-        <FIELD NAME="excluded" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="grade excluded from aggregation functions, date means when excluded"/>
-        <FIELD NAME="feedback" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="grading feedback"/>
-        <FIELD NAME="feedbackformat" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="format of feedback text"/>
-        <FIELD NAME="information" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="optiona information"/>
-        <FIELD NAME="informationformat" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="format of information text"/>
-        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="the time this grade was first created"/>
-        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="the time this grade was last modified"/>
-        <FIELD NAME="aggregationstatus" TYPE="char" LENGTH="10" NOTNULL="true" DEFAULT="unknown" SEQUENCE="false" COMMENT="One of several values describing how this grade_grade was used when calculating the aggregation. Possible values are &quot;unknown&quot;, &quot;dropped&quot;, &quot;novalue&quot;, &quot;used&quot;"/>
-        <FIELD NAME="aggregationweight" TYPE="number" LENGTH="10" NOTNULL="false" SEQUENCE="false" DECIMALS="5" COMMENT="If the aggregationstatus == 'included', then this is the percent this item contributed to the aggregation."/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-        <KEY NAME="itemid" TYPE="foreign" FIELDS="itemid" REFTABLE="grade_items" REFFIELDS="id"/>
-        <KEY NAME="userid" TYPE="foreign" FIELDS="userid" REFTABLE="user" REFFIELDS="id"/>
-        <KEY NAME="rawscaleid" TYPE="foreign" FIELDS="rawscaleid" REFTABLE="scale" REFFIELDS="id"/>
-        <KEY NAME="usermodified" TYPE="foreign" FIELDS="usermodified" REFTABLE="user" REFFIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="locked-locktime" UNIQUE="false" FIELDS="locked, locktime" COMMENT="used in grading cron"/>
       </INDEXES>
     </TABLE>
     <TABLE NAME="local_recompletion_qa" COMMENT="archive of quiz attempts table">

--- a/db/install.xml
+++ b/db/install.xml
@@ -10,6 +10,16 @@
         <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Course id"/>
         <FIELD NAME="enable" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Enable recompletion for this course"/>
         <FIELD NAME="recompletionduration" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Duration for recompletion"/>
+        <FIELD NAME="archivecompletiondata" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Archive completion data for this course"/>
+        <FIELD NAME="deletegradedata" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Delete current grade data for this course"/>
+        <FIELD NAME="archivegradedata" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Archive current grade data for this course"/>
+        <FIELD NAME="deletequizdata" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Delete quiz data for this course"/>
+        <FIELD NAME="archivequizdata" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Archive quiz data for this course"/>
+        <FIELD NAME="deletescormdata" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Delete scorm data for this course"/>
+        <FIELD NAME="archivescormdata" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Archive scorm data for this course"/>
+        <FIELD NAME="recompletionemailenable" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Enable recompletion email message for this course"/>
+        <FIELD NAME="recompletionemailheader" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Recompletion message subject"/>
+        <FIELD NAME="recompletionemailbody" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Recompletion message body"/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
@@ -70,6 +80,127 @@
       <INDEXES>
         <INDEX NAME="coursemoduleid" UNIQUE="false" FIELDS="coursemoduleid" COMMENT="For quick access via course-module (e.g. when displaying course module settings page and we need to determine whether anyone has completed it)."/>
       </INDEXES>
+    </TABLE>
+    <TABLE NAME="local_recompletion_gg" COMMENT="archive of grade_grades table">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="itemid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The item this grade belongs to"/>
+        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="The user who this grade is for"/>
+        <FIELD NAME="rawgrade" TYPE="number" LENGTH="10" NOTNULL="false" SEQUENCE="false" DECIMALS="5" COMMENT="If the grade is a float value (or has been converted to one)"/>
+        <FIELD NAME="rawgrademax" TYPE="number" LENGTH="10" NOTNULL="true" DEFAULT="100" SEQUENCE="false" DECIMALS="5" COMMENT="The maximum allowable grade when this was created"/>
+        <FIELD NAME="rawgrademin" TYPE="number" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" DECIMALS="5" COMMENT="The minimum allowable grade when this was created"/>
+        <FIELD NAME="rawscaleid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="If this grade is based on a scale, which one was it?"/>
+        <FIELD NAME="usermodified" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="the userid of the person who last modified this grade"/>
+        <FIELD NAME="finalgrade" TYPE="number" LENGTH="10" NOTNULL="false" SEQUENCE="false" DECIMALS="5" COMMENT="The final grade (cached) after all calculations are made"/>
+        <FIELD NAME="hidden" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="show 0, hide 1 or hide until date"/>
+        <FIELD NAME="locked" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="not locked 0, locked from date"/>
+        <FIELD NAME="locktime" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="automatic locking of final grade, 0 means none, date otherwise"/>
+        <FIELD NAME="exported" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="date of last grade export, 0 if none"/>
+        <FIELD NAME="overridden" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="indicates grade overridden from gradebook, 0 means none, date means overridden"/>
+        <FIELD NAME="excluded" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="grade excluded from aggregation functions, date means when excluded"/>
+        <FIELD NAME="feedback" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="grading feedback"/>
+        <FIELD NAME="feedbackformat" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="format of feedback text"/>
+        <FIELD NAME="information" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="optiona information"/>
+        <FIELD NAME="informationformat" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="format of information text"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="the time this grade was first created"/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="the time this grade was last modified"/>
+        <FIELD NAME="aggregationstatus" TYPE="char" LENGTH="10" NOTNULL="true" DEFAULT="unknown" SEQUENCE="false" COMMENT="One of several values describing how this grade_grade was used when calculating the aggregation. Possible values are &quot;unknown&quot;, &quot;dropped&quot;, &quot;novalue&quot;, &quot;used&quot;"/>
+        <FIELD NAME="aggregationweight" TYPE="number" LENGTH="10" NOTNULL="false" SEQUENCE="false" DECIMALS="5" COMMENT="If the aggregationstatus == 'included', then this is the percent this item contributed to the aggregation."/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="itemid" TYPE="foreign" FIELDS="itemid" REFTABLE="grade_items" REFFIELDS="id"/>
+        <KEY NAME="userid" TYPE="foreign" FIELDS="userid" REFTABLE="user" REFFIELDS="id"/>
+        <KEY NAME="rawscaleid" TYPE="foreign" FIELDS="rawscaleid" REFTABLE="scale" REFFIELDS="id"/>
+        <KEY NAME="usermodified" TYPE="foreign" FIELDS="usermodified" REFTABLE="user" REFFIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="locked-locktime" UNIQUE="false" FIELDS="locked, locktime" COMMENT="used in grading cron"/>
+      </INDEXES>
+    </TABLE>
+    <TABLE NAME="local_recompletion_qa" COMMENT="archive of quiz attempts table">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" COMMENT="Standard Moodle primary key."/>
+        <FIELD NAME="quiz" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Foreign key reference to the quiz that was attempted."/>
+        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Foreign key reference to the user whose attempt this is."/>
+        <FIELD NAME="attempt" TYPE="int" LENGTH="6" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Sequentially numbers this student's attempts at this quiz."/>
+        <FIELD NAME="uniqueid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Foreign key reference to the question_usage that holds the details of the the question_attempts that make up this quiz attempt."/>
+        <FIELD NAME="layout" TYPE="text" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="currentpage" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="preview" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="state" TYPE="char" LENGTH="16" NOTNULL="true" DEFAULT="inprogress" SEQUENCE="false" COMMENT="The current state of the attempts. 'inprogress', 'overdue', 'finished' or 'abandoned'."/>
+        <FIELD NAME="timestart" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Time when the attempt was started."/>
+        <FIELD NAME="timefinish" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Time when the attempt was submitted. 0 if the attempt has not been submitted yet."/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Last modified time."/>
+        <FIELD NAME="timecheckstate" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="Next time quiz cron should check attempt for state changes.  NULL means never check."/>
+        <FIELD NAME="sumgrades" TYPE="number" LENGTH="10" NOTNULL="false" SEQUENCE="false" DECIMALS="5" COMMENT="Total marks for this attempt."/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="quiz" TYPE="foreign" FIELDS="quiz" REFTABLE="quiz" REFFIELDS="id"/>
+        <KEY NAME="userid" TYPE="foreign" FIELDS="userid" REFTABLE="user" REFFIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="state-timecheckstate" UNIQUE="false" FIELDS="state, timecheckstate"/>
+      </INDEXES>
+    </TABLE>
+    <TABLE NAME="local_recompletion_qg" COMMENT="archive of quiz grades table">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="quiz" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Foreign key references quiz.id."/>
+        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Foreign key references user.id."/>
+        <FIELD NAME="grade" TYPE="number" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" DECIMALS="5" COMMENT="The overall grade from the quiz. Not affected by overrides in the gradebook."/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="The last time this grade changed."/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="quiz" TYPE="foreign" FIELDS="quiz" REFTABLE="quiz" REFFIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="userid" UNIQUE="false" FIELDS="userid"/>
+      </INDEXES>
+    </TABLE>
+    <TABLE NAME="local_recompletion_sst" COMMENT="archive of scorm_scoes_track table">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="scormid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="scoid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+        <FIELD NAME="attempt" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
+        <FIELD NAME="element" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="value" TYPE="text" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="scormid" TYPE="foreign" FIELDS="scormid" REFTABLE="scorm" REFFIELDS="id"/>
+        <KEY NAME="scoid" TYPE="foreign" FIELDS="scoid" REFTABLE="scorm_scoes" REFFIELDS="id"/>
+      </KEYS>
+      <INDEXES>
+        <INDEX NAME="userid" UNIQUE="false" FIELDS="userid"/>
+        <INDEX NAME="element" UNIQUE="false" FIELDS="element"/>
+      </INDEXES>
+    </TABLE>
+    <TABLE NAME="local_recompletion_sas" COMMENT="archive of scorm_aicc_session table">
+      <FIELDS>
+        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="id from user table"/>
+        <FIELD NAME="scormid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="id from scorm table"/>
+        <FIELD NAME="hacpsession" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" COMMENT="sessionid used to authenticate AICC HACP communication"/>
+        <FIELD NAME="scoid" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="id from scorm_scoes table"/>
+        <FIELD NAME="scormmode" TYPE="char" LENGTH="50" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="scormstatus" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="attempt" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="lessonstatus" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="sessiontime" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="time this session was created"/>
+        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="time this session was last used"/>
+      </FIELDS>
+      <KEYS>
+        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+        <KEY NAME="scormid" TYPE="foreign" FIELDS="scormid" REFTABLE="scorm" REFFIELDS="id"/>
+        <KEY NAME="userid" TYPE="foreign" FIELDS="userid" REFTABLE="user" REFFIELDS="id"/>
+      </KEYS>
     </TABLE>
   </TABLES>
 </XMLDB>

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -29,8 +29,8 @@ $tasks = array(
     array(
         'classname' => 'local_recompletion\task\check_recompletion',
         'blocking' => 0,
-        'minute' => 'R',
-        'hour' => 'R',
+        'minute' => '*',
+        'hour' => '*',
         'day' => '*',
         'dayofweek' => '*',
         'month' => '*'

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -116,63 +116,54 @@ function xmldb_local_recompletion_upgrade($oldversion) {
     }
     if ($oldversion < 2018012300) {
         // Add additional fields to local_recompletion table.
-        // Define field archivecompletiondata to be added to local_recompletion table.
-        $table = new xmldb_table('local_recompletion');
-        $field = new xmldb_field('archivecompletiondata', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'recompletionduration');
-
-        // Conditionally launch add field archivecompletiondata.
-        if (!$dbman->field_exists($table, $field)) {
-            $dbman->add_field($table, $field);
-        }
-
         // Define field deletegradedata to be added to local_recompletion table.
         $table = new xmldb_table('local_recompletion');
-        $field = new xmldb_field('deletegradedata', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'archivecompletiondata');
+        $field = new xmldb_field('deletegradedata', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'recompletionduration');
 
         // Conditionally launch add field deletegradedata.
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
         }
 
-        // Define field archivegradedata to be added to local_recompletion table.
-        $table = new xmldb_table('local_recompletion');
-        $field = new xmldb_field('archivegradedata', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'deletegradedata');
-
-        // Conditionally launch add field archivegradedata.
-        if (!$dbman->field_exists($table, $field)) {
-            $dbman->add_field($table, $field);
-        }
-
         // Define field deletequizdata to be added to local_recompletion table.
         $table = new xmldb_table('local_recompletion');
-        $field = new xmldb_field('deletequizdata', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'archivegradedata');
+        $field = new xmldb_field('deletequizdata', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'deletegradedata');
 
         // Conditionally launch add field deletequizdata.
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
         }
 
-        // Define field archivequizdata to be added to local_recompletion table.
-        $table = new xmldb_table('local_recompletion');
-        $field = new xmldb_field('archivequizdata', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'deletequizdata');
-
-        // Conditionally launch add field archivequizdata.
-        if (!$dbman->field_exists($table, $field)) {
-            $dbman->add_field($table, $field);
-        }
-
         // Define field deletescormdata to be added to local_recompletion table.
         $table = new xmldb_table('local_recompletion');
-        $field = new xmldb_field('deletescormdata', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'archivequizdata');
+        $field = new xmldb_field('deletescormdata', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'deletequizdata');
 
         // Conditionally launch add field deletescormdata.
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
         }
 
+        // Define field archivecompletiondata to be added to local_recompletion table.
+        $table = new xmldb_table('local_recompletion');
+        $field = new xmldb_field('archivecompletiondata', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'deletescromdata');
+
+        // Conditionally launch add field archivecompletiondata.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field archivequizdata to be added to local_recompletion table.
+        $table = new xmldb_table('local_recompletion');
+        $field = new xmldb_field('archivequizdata', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'archivecompletiondata');
+
+        // Conditionally launch add field archivequizdata.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
         // Define field archivescormdata to be added to local_recompletion table.
         $table = new xmldb_table('local_recompletion');
-        $field = new xmldb_field('archivescormdata', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'deletescormdata');
+        $field = new xmldb_field('archivescormdata', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'archivequizdata');
 
         // Conditionally launch add field archivescormdata.
         if (!$dbman->field_exists($table, $field)) {
@@ -188,65 +179,24 @@ function xmldb_local_recompletion_upgrade($oldversion) {
             $dbman->add_field($table, $field);
         }
 
-        // Define field recompletionemailheader to be added to local_recompletion table.
+        // Define field recompletionemailsubject to be added to local_recompletion table.
         $table = new xmldb_table('local_recompletion');
-        $field = new xmldb_field('recompletionemailheader', XMLDB_TYPE_TEXT, null, null, null, null, null, 'recompletionemailenabled');
+        $field = new xmldb_field('recompletionemailsubject', XMLDB_TYPE_TEXT, null, null, null, null, null,
+                'recompletionemailenabled');
 
-        // Conditionally launch add field recompletionemailheader.
+        // Conditionally launch add field recompletionemailsubject.
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
         }
 
         // Define field recompletionemailbody to be added to local_recompletion table.
         $table = new xmldb_table('local_recompletion');
-        $field = new xmldb_field('recompletionemailbody', XMLDB_TYPE_TEXT, null, null, null, null, null, 'recompletionemailheader');
+        $field = new xmldb_field('recompletionemailbody', XMLDB_TYPE_TEXT, null, null, null, null, null,
+                'recompletionemailsubject');
 
         // Conditionally launch add field recompletionemailbody.
         if (!$dbman->field_exists($table, $field)) {
             $dbman->add_field($table, $field);
-        }
-
-        // Define table local_recompletion_gg to be created.
-        $table = new xmldb_table('local_recompletion_gg');
-
-        // Adding fields to table local_recompletion_gg.
-        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
-        $table->add_field('itemid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
-        $table->add_field('userid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
-        $table->add_field('rawgrade', XMLDB_TYPE_NUMBER, '10, 5', null, null, null, null);
-        $table->add_field('rawgrademax', XMLDB_TYPE_NUMBER, '10, 5', null, XMLDB_NOTNULL, null, '100');
-        $table->add_field('rawgrademin', XMLDB_TYPE_NUMBER, '10, 5', null, XMLDB_NOTNULL, null, '0');
-        $table->add_field('rawscaleid', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
-        $table->add_field('usermodified', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
-        $table->add_field('finalgrade', XMLDB_TYPE_NUMBER, '10, 5', null, null, null, null);
-        $table->add_field('hidden', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
-        $table->add_field('locked', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
-        $table->add_field('locktime', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
-        $table->add_field('exported', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
-        $table->add_field('overridden', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
-        $table->add_field('excluded', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
-        $table->add_field('feedback', XMLDB_TYPE_TEXT, null, null, null, null, null);
-        $table->add_field('feedbackformat', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
-        $table->add_field('information', XMLDB_TYPE_TEXT, null, null, null, null, null);
-        $table->add_field('informationformat', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
-        $table->add_field('timecreated', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
-        $table->add_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
-        $table->add_field('aggregationstatus', XMLDB_TYPE_CHAR, '10', null, XMLDB_NOTNULL, null, 'unknown');
-        $table->add_field('aggregationweight', XMLDB_TYPE_NUMBER, '10, 5', null, null, null, null);
-
-        // Adding keys to table local_recompletion_gg.
-        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
-        $table->add_key('itemid', XMLDB_KEY_FOREIGN, array('itemid'), 'grade_items', array('id'));
-        $table->add_key('userid', XMLDB_KEY_FOREIGN, array('userid'), 'user', array('id'));
-        $table->add_key('rawscaleid', XMLDB_KEY_FOREIGN, array('rawscaleid'), 'scale', array('id'));
-        $table->add_key('usermodified', XMLDB_KEY_FOREIGN, array('usermodified'), 'user', array('id'));
-
-        // Adding indexes to table local_recompletion_gg.
-        $table->add_index('locked-locktime', XMLDB_INDEX_NOTUNIQUE, array('locked', 'locktime'));
-
-        // Conditionally launch create table for local_recompletion_gg.
-        if (!$dbman->table_exists($table)) {
-            $dbman->create_table($table);
         }
 
         // Define table local_recompletion_qa to be created.

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -114,4 +114,248 @@ function xmldb_local_recompletion_upgrade($oldversion) {
         // Recompletion savepoint reached.
         upgrade_plugin_savepoint(true, 2018011600, 'local', 'recompletion');
     }
+    if ($oldversion < 2018012300) {
+        // Add additional fields to local_recompletion table.
+        // Define field archivecompletiondata to be added to local_recompletion table.
+        $table = new xmldb_table('local_recompletion');
+        $field = new xmldb_field('archivecompletiondata', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'recompletionduration');
+
+        // Conditionally launch add field archivecompletiondata.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field deletegradedata to be added to local_recompletion table.
+        $table = new xmldb_table('local_recompletion');
+        $field = new xmldb_field('deletegradedata', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'archivecompletiondata');
+
+        // Conditionally launch add field deletegradedata.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field archivegradedata to be added to local_recompletion table.
+        $table = new xmldb_table('local_recompletion');
+        $field = new xmldb_field('archivegradedata', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'deletegradedata');
+
+        // Conditionally launch add field archivegradedata.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field deletequizdata to be added to local_recompletion table.
+        $table = new xmldb_table('local_recompletion');
+        $field = new xmldb_field('deletequizdata', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'archivegradedata');
+
+        // Conditionally launch add field deletequizdata.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field archivequizdata to be added to local_recompletion table.
+        $table = new xmldb_table('local_recompletion');
+        $field = new xmldb_field('archivequizdata', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'deletequizdata');
+
+        // Conditionally launch add field archivequizdata.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field deletescormdata to be added to local_recompletion table.
+        $table = new xmldb_table('local_recompletion');
+        $field = new xmldb_field('deletescormdata', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'archivequizdata');
+
+        // Conditionally launch add field deletescormdata.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field archivescormdata to be added to local_recompletion table.
+        $table = new xmldb_table('local_recompletion');
+        $field = new xmldb_field('archivescormdata', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'deletescormdata');
+
+        // Conditionally launch add field archivescormdata.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field recompletionemailenabled to be added to local_recompletion table.
+        $table = new xmldb_table('local_recompletion');
+        $field = new xmldb_field('recompletionemailenable', XMLDB_TYPE_INTEGER, '10', null, null, null, null, 'archivescormdata');
+
+        // Conditionally launch add field recompletionemailenabled.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field recompletionemailheader to be added to local_recompletion table.
+        $table = new xmldb_table('local_recompletion');
+        $field = new xmldb_field('recompletionemailheader', XMLDB_TYPE_TEXT, null, null, null, null, null, 'recompletionemailenabled');
+
+        // Conditionally launch add field recompletionemailheader.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define field recompletionemailbody to be added to local_recompletion table.
+        $table = new xmldb_table('local_recompletion');
+        $field = new xmldb_field('recompletionemailbody', XMLDB_TYPE_TEXT, null, null, null, null, null, 'recompletionemailheader');
+
+        // Conditionally launch add field recompletionemailbody.
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+
+        // Define table local_recompletion_gg to be created.
+        $table = new xmldb_table('local_recompletion_gg');
+
+        // Adding fields to table local_recompletion_gg.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('itemid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('userid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('rawgrade', XMLDB_TYPE_NUMBER, '10, 5', null, null, null, null);
+        $table->add_field('rawgrademax', XMLDB_TYPE_NUMBER, '10, 5', null, XMLDB_NOTNULL, null, '100');
+        $table->add_field('rawgrademin', XMLDB_TYPE_NUMBER, '10, 5', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('rawscaleid', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+        $table->add_field('usermodified', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+        $table->add_field('finalgrade', XMLDB_TYPE_NUMBER, '10, 5', null, null, null, null);
+        $table->add_field('hidden', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('locked', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('locktime', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('exported', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('overridden', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('excluded', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('feedback', XMLDB_TYPE_TEXT, null, null, null, null, null);
+        $table->add_field('feedbackformat', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('information', XMLDB_TYPE_TEXT, null, null, null, null, null);
+        $table->add_field('informationformat', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('timecreated', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+        $table->add_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+        $table->add_field('aggregationstatus', XMLDB_TYPE_CHAR, '10', null, XMLDB_NOTNULL, null, 'unknown');
+        $table->add_field('aggregationweight', XMLDB_TYPE_NUMBER, '10, 5', null, null, null, null);
+
+        // Adding keys to table local_recompletion_gg.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+        $table->add_key('itemid', XMLDB_KEY_FOREIGN, array('itemid'), 'grade_items', array('id'));
+        $table->add_key('userid', XMLDB_KEY_FOREIGN, array('userid'), 'user', array('id'));
+        $table->add_key('rawscaleid', XMLDB_KEY_FOREIGN, array('rawscaleid'), 'scale', array('id'));
+        $table->add_key('usermodified', XMLDB_KEY_FOREIGN, array('usermodified'), 'user', array('id'));
+
+        // Adding indexes to table local_recompletion_gg.
+        $table->add_index('locked-locktime', XMLDB_INDEX_NOTUNIQUE, array('locked', 'locktime'));
+
+        // Conditionally launch create table for local_recompletion_gg.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Define table local_recompletion_qa to be created.
+        $table = new xmldb_table('local_recompletion_qa');
+
+        // Adding fields to table local_recompletion_qa.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('quiz', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('userid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('attempt', XMLDB_TYPE_INTEGER, '6', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('uniqueid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('layout', XMLDB_TYPE_TEXT, null, null, XMLDB_NOTNULL, null, null);
+        $table->add_field('currentpage', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('preview', XMLDB_TYPE_INTEGER, '3', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('state', XMLDB_TYPE_CHAR, '16', null, XMLDB_NOTNULL, null, 'inprogress');
+        $table->add_field('timestart', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('timefinish', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('timecheckstate', XMLDB_TYPE_INTEGER, '10', null, null, null, '0');
+        $table->add_field('sumgrades', XMLDB_TYPE_NUMBER, '10, 5', null, null, null, null);
+
+        // Adding keys to table local_recompletion_qa.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+        $table->add_key('quiz', XMLDB_KEY_FOREIGN, array('quiz'), 'quiz', array('id'));
+        $table->add_key('userid', XMLDB_KEY_FOREIGN, array('userid'), 'user', array('id'));
+
+        // Adding indexes to table local_recompletion_qa.
+        $table->add_index('state-timecheckstate', XMLDB_INDEX_NOTUNIQUE, array('state', 'timecheckstate'));
+
+        // Conditionally launch create table for local_recompletion_qa.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Define table local_recompletion_qg to be created.
+        $table = new xmldb_table('local_recompletion_qg');
+
+        // Adding fields to table local_recompletion_qg.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('quiz', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('userid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('grade', XMLDB_TYPE_NUMBER, '10, 5', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+
+        // Adding keys to table local_recompletion_qg.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+        $table->add_key('quiz', XMLDB_KEY_FOREIGN, array('quiz'), 'quiz', array('id'));
+
+        // Adding indexes to table local_recompletion_qg.
+        $table->add_index('userid', XMLDB_INDEX_NOTUNIQUE, array('userid'));
+
+        // Conditionally launch create table for local_recompletion_qg.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+        // Define table local_recompletion_sst to be created.
+        $table = new xmldb_table('local_recompletion_sst');
+
+        // Adding fields to table local_recompletion_sst.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('userid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('scormid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('scoid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('attempt', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '1');
+        $table->add_field('element', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('value', XMLDB_TYPE_TEXT, null, null, XMLDB_NOTNULL, null, null);
+        $table->add_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+
+        // Adding keys to table local_recompletion_sst.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+        $table->add_key('scormid', XMLDB_KEY_FOREIGN, array('scormid'), 'scorm', array('id'));
+        $table->add_key('scoid', XMLDB_KEY_FOREIGN, array('scoid'), 'scorm_scoes', array('id'));
+
+        // Adding indexes to table local_recompletion_sst.
+        $table->add_index('userid', XMLDB_INDEX_NOTUNIQUE, array('userid'));
+        $table->add_index('element', XMLDB_INDEX_NOTUNIQUE, array('element'));
+
+        // Conditionally launch create table for local_recompletion_sst.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+        // Define table local_recompletion_sas to be created.
+        $table = new xmldb_table('local_recompletion_sas');
+
+        // Adding fields to table local_recompletion_sas.
+        $table->add_field('id', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, XMLDB_SEQUENCE, null);
+        $table->add_field('userid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('scormid', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('hacpsession', XMLDB_TYPE_CHAR, '255', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('scoid', XMLDB_TYPE_INTEGER, '10', null, null, null, '0');
+        $table->add_field('scormmode', XMLDB_TYPE_CHAR, '50', null, null, null, null);
+        $table->add_field('scormstatus', XMLDB_TYPE_CHAR, '255', null, null, null, null);
+        $table->add_field('attempt', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
+        $table->add_field('lessonstatus', XMLDB_TYPE_CHAR, '255', null, null, null, null);
+        $table->add_field('sessiontime', XMLDB_TYPE_CHAR, '255', null, null, null, null);
+        $table->add_field('timecreated', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+        $table->add_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
+
+        // Adding keys to table local_recompletion_sas.
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+        $table->add_key('scormid', XMLDB_KEY_FOREIGN, array('scormid'), 'scorm', array('id'));
+        $table->add_key('userid', XMLDB_KEY_FOREIGN, array('userid'), 'user', array('id'));
+
+        // Conditionally launch create table for local_recompletion_sas.
+        if (!$dbman->table_exists($table)) {
+            $dbman->create_table($table);
+        }
+
+        // Recompletion savepoint reached.
+        upgrade_plugin_savepoint(true, 2018012300, 'local', 'recompletion');
+    }
 }

--- a/lang/en/local_recompletion.php
+++ b/lang/en/local_recompletion.php
@@ -32,43 +32,41 @@ $string['recompletionsettingssaved'] = 'Recompletion settings saved';
 $string['recompletion:manage'] = 'Allow course recompletion settings to be changed';
 $string['recompletiontask'] = 'Check for users that need to recomplete';
 $string['completionnotenabled'] = 'Completion is not enabled in this course';
-$string['recompletionemailsubject'] = 'Course {$a->coursename} recompletion required';
-$string['recompletionemailcontent'] = 'Hi there, please recomplete the course {$a->coursename} {$a->link}';
-$string['archivecompletiondata'] = 'Archive completion data';
-$string['archivecompletiondata_help'] = 'Writes course completion data to an archive table. Course completion data is deleted if this is not selected.';
-$string['graderecompletiontitle'] = 'Current grade data settings';
-$string['deletegradedata'] = 'Delete current grade data';
-$string['deletegradedata_help'] = 'Deletes current grade completion data. Grade recompletion data is permanently deleted if archive grade data is not selected. Grade history data is not affected.';
-$string['archivegradedata'] = 'Archive current grade data';
-$string['archivegradedata_help'] = 'Writes current grade completion data to an archive table before removing. Current grade completion data is permanentely deleted if this is not selected. Grade history data is not affected.';
-$string['quizrecompletiontitle'] = 'Quiz data settings';
-$string['deletequizdata'] = 'Delete quiz data';
-$string['deletequizdata_help'] = 'Deletes quiz module completion data. Quiz module completion data is permanently deleted if archive quiz data is not selected.';
-$string['archivequizdata'] = 'Archive quiz data';
-$string['archivequizdata_help'] = 'Writes quiz module data to an archive table before removing. Quiz module completion data is permanentely deleted if this is not selected.';
-$string['scormrecompletiontitle'] = 'SCORM data settings';
-$string['deletescormdata'] = 'Delete SCORM data';
-$string['deletescormdata_help'] = 'Deletes SCORM module completion data. SCORM module completion data is permanently deleted if archive quiz data is not selected.';
-$string['archivescormdata'] = 'Archive SCORM data';
-$string['archivescormdata_help'] = 'Writes SCORM module data to an archive table before removing. SCORM module completion data is permanentely deleted if this is not selected.';
-$string['emailrecompletiontitle'] = 'Recompletion message settings';
 $string['recompletionemailenable'] = 'Send recompletion message';
-$string['recompletionemailenable_help'] = 'Enable email to use to notify them that recompletion is required';
-$string['recompletionemailheader'] = 'Custom recompletion message subject';
-$string['recompletionemailheader_help'] = 'A custom recompletion email subject may be added as plain text
+$string['recompletionemailenable_help'] = 'Enable email messaging to notifiy users that recompletion is required';
+$string['recompletionemailsubject'] = 'Recompletion message subject';
+$string['recompletionemailsubject_help'] = 'A custom recompletion email subject may be added as plain text
 
-The folowing placeholders may be included in the message:
+The following placeholders may be included in the message:
 
 * Course name {$a->coursename}
 * User fullname {$a->fullname}';
-
-$string['recompletionemailbody'] = 'Custom recompletion message body';
+$string['recompletionemaildefaultsubject'] = 'Course {$a->coursename} recompletion required';
+$string['recompletionemailbody'] = 'Recompletion message body';
 $string['recompletionemailbody_help'] = 'A custom recompletion email subject may be added as plain text or Moodle-auto format, including HTML tags and multi-lang tags
 
-The folowing placeholders may be included in the message:
+The following placeholders may be included in the message:
 
 * Course name {$a->coursename}
 * Link to course {$a->link}
 * Link to user\'s profile page {$a->profileurl}
 * User email {$a->email}
 * User fullname {$a->fullname}';
+$string['recompletionemaildefaultbody'] = 'Hi there, please recomplete the course {$a->coursename} {$a->link}';
+$string['advancedrecompletiontitle'] = 'Advanced';
+$string['deletewhichdata'] = 'Select deletion criteria';
+$string['deletegradedata'] = 'Delete current grade data';
+$string['deletegradedata_help'] = 'Delete current grade completion data from grade_grades table. Grade recompletion data is permanently deleted but data retained in Grade history data table.';
+$string['deletequizdata'] = 'Delete quiz data';
+$string['deletequizdata_help'] = 'Delete quiz module completion data from quiz_attempts and quiz_grades tables. Quiz module completion data is permanently deleted if archive quiz data is not selected.';
+$string['deletescormdata'] = 'Delete SCORM data';
+$string['deletescormdata_help'] = 'Delete SCORM module completion data from the scorm_scoes_track and scorm_aicc_session tables. SCORM module completion data is permanently deleted if archive quiz data is not selected.';
+$string['archivewhichdata'] = 'Select archive criteria';
+$string['archivecompletiondata'] = 'Archive completion data';
+$string['archivecompletiondata_help'] = 'Writes course completion data to the local_recompletion_cc, local_recompletion_cc_cc and local_recompletion_cmc tables. Completion data will be permanently deleted if this is not selected.';
+$string['archivequizdata'] = 'Archive quiz data';
+$string['archivequizdata_help'] = 'Archive quiz module data to the local_recompletion_qa and local_recompletion_qg tables before removing. Quiz module completion data is permanentely deleted if this is not selected.';
+$string['archivescormdata'] = 'Archive SCORM data';
+$string['archivescormdata_help'] = 'Archive SCORM module data to the local_recompletion_sst and local_recompletion_sas tables before removing. SCORM module completion data is permanentely deleted if this is not selected.';
+$string['emailrecompletiontitle'] = 'Custom recompletion message settings';
+

--- a/lang/en/local_recompletion.php
+++ b/lang/en/local_recompletion.php
@@ -25,10 +25,50 @@
 $string['pluginname'] = 'Course recompletion';
 $string['editrecompletion'] = 'Edit course recompletion settings';
 $string['enablerecompletion'] = 'Enable recompletion';
+$string['enablerecompletion_help'] = 'The recompletion plugin allows a course completion details to be reset after a defined period.';
 $string['recompletionrange'] = 'Recompletion period';
+$string['recompletionrange_help'] = 'Set the period of time before a users completion results are reset.';
 $string['recompletionsettingssaved'] = 'Recompletion settings saved';
 $string['recompletion:manage'] = 'Allow course recompletion settings to be changed';
 $string['recompletiontask'] = 'Check for users that need to recomplete';
 $string['completionnotenabled'] = 'Completion is not enabled in this course';
-$string['recompletionemailsubject'] = 'Course recompletion required';
-$string['recompletionemailcontent'] = 'Hi there, please recomplete the course {$a->name} {$a->link}';
+$string['recompletionemailsubject'] = 'Course {$a->coursename} recompletion required';
+$string['recompletionemailcontent'] = 'Hi there, please recomplete the course {$a->coursename} {$a->link}';
+$string['archivecompletiondata'] = 'Archive completion data';
+$string['archivecompletiondata_help'] = 'Writes course completion data to an archive table. Course completion data is deleted if this is not selected.';
+$string['graderecompletiontitle'] = 'Current grade data settings';
+$string['deletegradedata'] = 'Delete current grade data';
+$string['deletegradedata_help'] = 'Deletes current grade completion data. Grade recompletion data is permanently deleted if archive grade data is not selected. Grade history data is not affected.';
+$string['archivegradedata'] = 'Archive current grade data';
+$string['archivegradedata_help'] = 'Writes current grade completion data to an archive table before removing. Current grade completion data is permanentely deleted if this is not selected. Grade history data is not affected.';
+$string['quizrecompletiontitle'] = 'Quiz data settings';
+$string['deletequizdata'] = 'Delete quiz data';
+$string['deletequizdata_help'] = 'Deletes quiz module completion data. Quiz module completion data is permanently deleted if archive quiz data is not selected.';
+$string['archivequizdata'] = 'Archive quiz data';
+$string['archivequizdata_help'] = 'Writes quiz module data to an archive table before removing. Quiz module completion data is permanentely deleted if this is not selected.';
+$string['scormrecompletiontitle'] = 'SCORM data settings';
+$string['deletescormdata'] = 'Delete SCORM data';
+$string['deletescormdata_help'] = 'Deletes SCORM module completion data. SCORM module completion data is permanently deleted if archive quiz data is not selected.';
+$string['archivescormdata'] = 'Archive SCORM data';
+$string['archivescormdata_help'] = 'Writes SCORM module data to an archive table before removing. SCORM module completion data is permanentely deleted if this is not selected.';
+$string['emailrecompletiontitle'] = 'Recompletion message settings';
+$string['recompletionemailenable'] = 'Send recompletion message';
+$string['recompletionemailenable_help'] = 'Enable email to use to notify them that recompletion is required';
+$string['recompletionemailheader'] = 'Custom recompletion message subject';
+$string['recompletionemailheader_help'] = 'A custom recompletion email subject may be added as plain text
+
+The folowing placeholders may be included in the message:
+
+* Course name {$a->coursename}
+* User fullname {$a->fullname}';
+
+$string['recompletionemailbody'] = 'Custom recompletion message body';
+$string['recompletionemailbody_help'] = 'A custom recompletion email subject may be added as plain text or Moodle-auto format, including HTML tags and multi-lang tags
+
+The folowing placeholders may be included in the message:
+
+* Course name {$a->coursename}
+* Link to course {$a->link}
+* Link to user\'s profile page {$a->profileurl}
+* User email {$a->email}
+* User fullname {$a->fullname}';

--- a/recompletion.php
+++ b/recompletion.php
@@ -76,10 +76,30 @@ if ($form->is_cancelled()) {
         $recompletion->course = $course->id;
         $recompletion->enable = $data->enable;
         $recompletion->recompletionduration = $data->recompletionduration;
+        $recompletion->archivecompletiondata = isset($data->archivecompletiondata) ? $data->archivecompletiondata : 0;
+        $recompletion->deletegradedata = isset($data->deletegradedata) ? $data->deletegradedata : 0;
+        $recompletion->archivegradedata = isset($data->archivegradedata) ? $data->archivegradedata : 0;
+        $recompletion->deletequizdata = isset($data->deletequizdata) ? $data->deletequizdata : 0;
+        $recompletion->archivequizdata = isset($data->archivequizdata) ? $data->archivequizdata : 0;
+        $recompletion->deletescormdata = isset($data->deletescormdata) ? $data->deletescormdata : 0;
+        $recompletion->archivescormdata = isset($data->archivescormdata) ? $data->archivescormdata : 0;
+        $recompletion->recompletionemailenable = isset($data->recompletionemailenable) ? $data->recompletionemailenable : 0;
+        $recompletion->recompletionemailheader = isset($data->recompletionemailheader) ? $data->recompletionemailheader : '';
+        $recompletion->recompletionemailbody = isset($data->recompletionemailbody) ? $data->recompletionemailbody : '';
         $DB->insert_record('local_recompletion', $recompletion);
     } else {
         $existing->enable = isset($data->enable) ? $data->enable : 0;
         $existing->recompletionduration = $data->recompletionduration;
+        $existing->archivecompletiondata = isset($data->archivecompletiondata) ? $data->archivecompletiondata : 0;
+        $existing->deletegradedata = isset($data->deletegradedata) ? $data->deletegradedata : 0;
+        $existing->archivegradedata = isset($data->archivegradedata) ? $data->archivegradedata : 0;
+        $existing->deletequizdata = isset($data->deletequizdata) ? $data->deletequizdata : 0;
+        $existing->archivequizdata = isset($data->archivequizdata) ? $data->archivequizdata : 0;
+        $existing->deletescormdata = isset($data->deletescormdata) ? $data->deletescormdata : 0;
+        $existing->archivescormdata = isset($data->archivescormdata) ? $data->archivescormdata : 0;
+        $existing->recompletionemailenable = isset($data->recompletionemailenable) ? $data->recompletionemailenable : 0;
+        $existing->recompletionemailheader = isset($data->recompletionemailheader) ? $data->recompletionemailheader : '';
+        $existing->recompletionemailbody = isset($data->recompletionemailbody) ? $data->recompletionemailbody : '';
         $DB->update_record('local_recompletion', $existing);
     }
     // Redirect to the course main page.

--- a/recompletion.php
+++ b/recompletion.php
@@ -74,31 +74,29 @@ if ($form->is_cancelled()) {
     if (empty($existing)) {
         $recompletion = new stdClass();
         $recompletion->course = $course->id;
-        $recompletion->enable = $data->enable;
+        $recompletion->enable = isset($data->enable) ? $data->enable : 0;
         $recompletion->recompletionduration = $data->recompletionduration;
-        $recompletion->archivecompletiondata = isset($data->archivecompletiondata) ? $data->archivecompletiondata : 0;
         $recompletion->deletegradedata = isset($data->deletegradedata) ? $data->deletegradedata : 0;
-        $recompletion->archivegradedata = isset($data->archivegradedata) ? $data->archivegradedata : 0;
         $recompletion->deletequizdata = isset($data->deletequizdata) ? $data->deletequizdata : 0;
-        $recompletion->archivequizdata = isset($data->archivequizdata) ? $data->archivequizdata : 0;
         $recompletion->deletescormdata = isset($data->deletescormdata) ? $data->deletescormdata : 0;
+        $recompletion->archivecompletiondata = isset($data->archivecompletiondata) ? $data->archivecompletiondata : 0;
+        $recompletion->archivequizdata = isset($data->archivequizdata) ? $data->archivequizdata : 0;
         $recompletion->archivescormdata = isset($data->archivescormdata) ? $data->archivescormdata : 0;
         $recompletion->recompletionemailenable = isset($data->recompletionemailenable) ? $data->recompletionemailenable : 0;
-        $recompletion->recompletionemailheader = isset($data->recompletionemailheader) ? $data->recompletionemailheader : '';
+        $recompletion->recompletionemailsubject = isset($data->recompletionemailsubject) ? $data->recompletionemailsubject : '';
         $recompletion->recompletionemailbody = isset($data->recompletionemailbody) ? $data->recompletionemailbody : '';
         $DB->insert_record('local_recompletion', $recompletion);
     } else {
         $existing->enable = isset($data->enable) ? $data->enable : 0;
         $existing->recompletionduration = $data->recompletionduration;
-        $existing->archivecompletiondata = isset($data->archivecompletiondata) ? $data->archivecompletiondata : 0;
         $existing->deletegradedata = isset($data->deletegradedata) ? $data->deletegradedata : 0;
-        $existing->archivegradedata = isset($data->archivegradedata) ? $data->archivegradedata : 0;
         $existing->deletequizdata = isset($data->deletequizdata) ? $data->deletequizdata : 0;
-        $existing->archivequizdata = isset($data->archivequizdata) ? $data->archivequizdata : 0;
         $existing->deletescormdata = isset($data->deletescormdata) ? $data->deletescormdata : 0;
+        $existing->archivecompletiondata = isset($data->archivecompletiondata) ? $data->archivecompletiondata : 0;
+        $existing->archivequizdata = isset($data->archivequizdata) ? $data->archivequizdata : 0;
         $existing->archivescormdata = isset($data->archivescormdata) ? $data->archivescormdata : 0;
         $existing->recompletionemailenable = isset($data->recompletionemailenable) ? $data->recompletionemailenable : 0;
-        $existing->recompletionemailheader = isset($data->recompletionemailheader) ? $data->recompletionemailheader : '';
+        $existing->recompletionemailsubject = isset($data->recompletionemailsubject) ? $data->recompletionemailsubject : '';
         $existing->recompletionemailbody = isset($data->recompletionemailbody) ? $data->recompletionemailbody : '';
         $DB->update_record('local_recompletion', $existing);
     }
@@ -106,7 +104,9 @@ if ($form->is_cancelled()) {
     $url = new moodle_url('/course/view.php', array('id' => $course->id));
     redirect($url, get_string('recompletionsettingssaved', 'local_recompletion'));
 } else if (!empty($existing)) {
-    $form->set_data($existing);
+    if ($existing->enable) {
+        $form->set_data($existing);
+    }
 }
 
 // Print the form.

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2018011600;
-$plugin->release   = '1.2';
+$plugin->version   = 2018012300;
+$plugin->release   = '1.3';
 $plugin->maturity  = MATURITY_ALPHA;
 $plugin->requires  = 2016052307; // Moodle 3.1.7 release and upwards.
 $plugin->component = 'local_recompletion';


### PR DESCRIPTION
Upgraded code to allow deletion/archive of the following data
- Current Grade Data (Not History)
- Quiz Data
- SCORM Data
To allow a course to be fully reset for recompletion.
Email notification is now optional/configurable and HTML compatible.