### PR TITLE
39 - Fix schema alignment and defaulting for the 'course' field

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -401,7 +401,7 @@ function xmldb_local_recompletion_upgrade($oldversion) {
         $table->add_field('complete', XMLDB_TYPE_CHAR, '1', null, XMLDB_NOTNULL, null, 'n');
         $table->add_field('grade', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
         $table->add_field('userid', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
-        $table->add_field('course', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
+        $table->add_field('course', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
 
         // Adding keys to table local_recompletion_qr.
         $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
@@ -556,6 +556,15 @@ function xmldb_local_recompletion_upgrade($oldversion) {
 
         // Recompletion savepoint reached.
         upgrade_plugin_savepoint(true, 2021091500, 'local', 'recompletion');
+    }
+
+    if ($oldversion < 2021100101) {
+        // Correct default value for couse on the local_recompletion_qr table to be zero.
+        $table = new xmldb_table('local_recompletion_qr');
+        $field = new xmldb_field('course', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0', 'userid');
+        $dbman->change_field_default($table, $field);
+        // Recompletion savepoint reached.
+        upgrade_plugin_savepoint(true, 2021100101, 'local', 'recompletion');
     }
 
     return true;

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2021100100;
-$plugin->release   = '2021092000';
+$plugin->version   = 2021100101;
+$plugin->release   = '2021100101';
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->requires  = 2020061500; // Requires 3.9.
 $plugin->component = 'local_recompletion';


### PR DESCRIPTION
Closes #49

- QR set to have a default value in install.xml but was not set to have
  the same default in upgrade.php. This patch fixes that issue.

```
local_recompletion_qr

column 'course' has default 'NULL', expected '0' (I)
```