### PR TITLE
Add support for mod_pulse

### DIFF
--- a/classes/activities/pulse.php
+++ b/classes/activities/pulse.php
@@ -1,0 +1,124 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Pulse handler event.
+ *
+ * @package     local_recompletion
+ * @copyright   2022 Alexander Bias, lern.link GmbH <alexander.bias@lernlink.de>
+ * @copyright   based on code by Dan Marsden, Catalyst IT
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace local_recompletion\activities;
+
+use lang_string;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Pulse handler event.
+ *
+ * @package    local_recompletion
+ * @copyright  2022 Alexander Bias, lern.link GmbH <alexander.bias@lernlink.de>
+ * @copyright  based on code by Dan Marsden, Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ */
+class pulse {
+    /**
+     * Add params to form.
+     *
+     * @param moodleform $mform
+     *
+     * @throws \coding_exception
+     * @throws \dml_exception
+     */
+    public static function editingform($mform): void {
+        if (!self::installed()) {
+            return;
+        }
+        $config = get_config('local_recompletion');
+
+        $cba = array();
+        $cba[] = $mform->createElement('radio', 'pulse', '',
+                get_string('donothing', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING);
+        $cba[] = $mform->createElement('radio', 'pulse', '',
+                get_string('pulseresetnotifications', 'local_recompletion'), LOCAL_RECOMPLETION_DELETE);
+
+        $mform->addGroup($cba, 'pulse', get_string('pulsenotifications', 'local_recompletion'), array(' '), false);
+        $mform->addHelpButton('pulse', 'pulsenotifications', 'local_recompletion');
+        $mform->setDefault('pulse', $config->pulsenotifications);
+    }
+
+    /**
+     * Add sitelevel settings for this plugin.
+     *
+     * @param admin_settingpage $settings
+     */
+    public static function settings($settings) {
+        if (!self::installed()) {
+            return;
+        }
+        $choices = array(LOCAL_RECOMPLETION_NOTHING => get_string('donothing', 'local_recompletion'),
+                LOCAL_RECOMPLETION_DELETE => get_string('pulseresetnotifications', 'local_recompletion'));
+        $settings->add(new \admin_setting_configselect('local_recompletion/pulsenotifications',
+                new lang_string('pulsenotifications', 'local_recompletion'),
+                new lang_string('pulsenotifications_help', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING, $choices));
+    }
+
+    /**
+     * Reset pulse notification records.
+     *
+     * @param \stdclass $userid - user id
+     * @param \stdClass $course - course record.
+     * @param \stdClass $config - recompletion config.
+     */
+    public static function reset($userid, $course, $config) {
+        global $CFG, $DB;
+        if (!self::installed()) {
+            return;
+        }
+
+        if (empty($config->pulse)) {
+            return;
+        } else if ($config->pulse == LOCAL_RECOMPLETION_DELETE) {
+            // Prepare SQL Query.
+            $params = array('userid' => $userid, 'course' => $course->id);
+            $selectsql = 'userid = ? AND pulseid IN (SELECT id FROM {pulse} WHERE course = ?)';
+
+            // Delete records from pulse_users.
+            $DB->delete_records_select('pulse_users', $selectsql, $params);
+
+            // If Pulse Pro is installed, delete records from local_pulsepro_availability as well.
+            if (file_exists($CFG->dirroot . '/local/pulsepro/version.php')) {
+                $DB->delete_records_select('local_pulsepro_availability', $selectsql, $params);
+            }
+        }
+    }
+
+    /**
+     * Helper function to check if pulse is installed.
+     * @return bool
+     */
+    public static function installed() {
+        global $CFG;
+        if (!file_exists($CFG->dirroot.'/mod/pulse/version.php')) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/lang/en/local_recompletion.php
+++ b/lang/en/local_recompletion.php
@@ -150,3 +150,6 @@ $string['resetltis'] = 'LTI grades';
 $string['resetltis_help'] = 'How to handle LTI grades within the course.
 If the setting \'Reset LTI grades\' is used, all grade LTI results will be reset to 0.
 When user achieved new completion in the course, the updated course grade will be resend to the LTI provider.';
+$string['pulsenotifications'] = 'Pulse notifications';
+$string['pulsenotifications_help'] = 'Should Pulse notifications which have already been sent be reset?';
+$string['pulseresetnotifications'] = 'Reset notifications';


### PR DESCRIPTION
Hi Dan,

as discussed, I would like to ask you to add support for mod_pulse (https://moodle.org/plugins/mod_pulse) to this plugin. 
I have built the necessary code based on your existing support for mod_scorm. 
Basically, nothing special is necessary for resetting mod_pulse, just delete the user's entries for the course in mod_scorm's database table.

You just have to be aware that mod_pulse also has a paid pro addon (see https://bdecent.de/product/pulse-pro/) which ships with additional tables. The reset code checks if the pro addon is also there and deletes the entries from the pro tables as well.

I have built the code for the 3.9 branch of the plugin (for which we need it in production for some more weeks) and I would be grateful if you could integrate it there and then port it over to the 3.11+ branch yourself.

Cheers,
Alex