### PR TITLE
Add new option for manually triggered runs.

### DIFF
--- a/classes/observer.php
+++ b/classes/observer.php
@@ -41,7 +41,7 @@ class local_recompletion_observer {
         $course = $assign->get_course();
         // Check if recompletion enabled.
         $config = local_recompletion_get_config($course);
-        if (!empty($config->enable) && !empty($config->assignevent)) {
+        if (!empty($config->recompletiontype) && !empty($config->assignevent)) {
             $params = array(
                 'userid'    => $event->relateduserid,
                 'course'    => $course->id

--- a/classes/recompletion_form.php
+++ b/classes/recompletion_form.php
@@ -29,7 +29,14 @@
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class local_recompletion_recompletion_form extends moodleform {
+    /** @var string */
+    const RECOMPLETION_TYPE_DISABLED = '';
 
+    /** @var string */
+    const RECOMPLETION_TYPE_PERIOD = 'period';
+
+    /** @var string */
+    const RECOMPLETION_TYPE_ONDEMAND = 'ondemand';
     /**
      * Defines the form fields.
      */
@@ -53,19 +60,24 @@ class local_recompletion_recompletion_form extends moodleform {
             'rows' => '8'
         );
 
-        $mform->addElement('checkbox', 'enable', get_string('enablerecompletion', 'local_recompletion'));
-        $mform->addHelpButton('enable', 'enablerecompletion', 'local_recompletion');
+        $mform->addElement('select', 'recompletiontype', get_string('recompletiontype', 'local_recompletion'), [
+            self::RECOMPLETION_TYPE_DISABLED => get_string('recompletiontype:disabled', 'local_recompletion'),
+            self::RECOMPLETION_TYPE_PERIOD => get_string('recompletiontype:period', 'local_recompletion'),
+            self::RECOMPLETION_TYPE_ONDEMAND => get_string('recompletiontype:ondemand', 'local_recompletion'),
+        ]);
+        $mform->setDefault('recompletiontype', $config->recompletiontype ?? '');
+        $mform->addHelpButton('recompletiontype', 'recompletiontype', 'local_recompletion');
 
         $options = array('optional' => false, 'defaultunit' => 86400);
         $mform->addElement('duration', 'recompletionduration', get_string('recompletionrange', 'local_recompletion'), $options);
         $mform->addHelpButton('recompletionduration', 'recompletionrange', 'local_recompletion');
-        $mform->disabledIf('recompletionduration', 'enable', 'notchecked');
+        $mform->hideIf('recompletionduration', 'recompletiontype', 'not', 'period');
         $mform->setDefault('recompletionduration', $config->duration);
 
         $mform->addElement('checkbox', 'recompletionemailenable', get_string('recompletionemailenable', 'local_recompletion'));
         $mform->setDefault('recompletionemailenable', $config->emailenable);
         $mform->addHelpButton('recompletionemailenable', 'recompletionemailenable', 'local_recompletion');
-        $mform->disabledIf('recompletionemailenable', 'enable', 'notchecked');
+        $mform->hideIf('recompletionemailenable', 'recompletiontype', 'eq', '');
 
         // Email Notification settings.
         $mform->addElement('header', 'emailheader', get_string('emailrecompletiontitle', 'local_recompletion'));
@@ -74,7 +86,7 @@ class local_recompletion_recompletion_form extends moodleform {
                 'size = "80"');
         $mform->setType('recompletionemailsubject', PARAM_TEXT);
         $mform->addHelpButton('recompletionemailsubject', 'recompletionemailsubject', 'local_recompletion');
-        $mform->disabledIf('recompletionemailsubject', 'enable', 'notchecked');
+        $mform->disabledIf('recompletionemailsubject', 'recompletiontype', 'eq', '');
         $mform->disabledIf('recompletionemailsubject', 'recompletionemailenable', 'notchecked');
         $mform->setDefault('recompletionemailsubject', $config->emailsubject);
 
@@ -83,7 +95,7 @@ class local_recompletion_recompletion_form extends moodleform {
         $mform->setDefault('recompletionemailbody', array('text' => $config->emailbody,
             'format' => FORMAT_HTML));
         $mform->addHelpButton('recompletionemailbody', 'recompletionemailbody', 'local_recompletion');
-        $mform->disabledIf('recompletionemailbody', 'enable', 'notchecked');
+        $mform->disabledIf('recompletionemailbody', 'recompletiontype', 'eq', '');
         $mform->disabledIf('recompletionemailbody', 'recompletionemailenable', 'notchecked');
 
         // Advanced recompletion settings.
@@ -108,8 +120,8 @@ class local_recompletion_recompletion_form extends moodleform {
             $fqn::editingform($mform);
         }
 
-        $mform->disabledIf('deletegradedata', 'enable', 'notchecked');
-        $mform->disabledIf('archivecompletiondata', 'enable', 'notchecked');
+        $mform->disabledIf('deletegradedata', 'recompletiontype', 'eq', '');
+        $mform->disabledIf('archivecompletiondata', 'recompletiontype', 'eq', '');
         $mform->disabledIf('archivecompletiondata', 'forcearchive', 'eq');
 
         // Add common action buttons.

--- a/classes/table/participants.php
+++ b/classes/table/participants.php
@@ -149,7 +149,7 @@ class participants extends \core_user\table\participants {
         $this->profileroles = get_profile_roles($this->context);
         $this->viewableroles = get_viewable_roles($this->context);
         $this->recompletionenabled = $DB->get_field('local_recompletion_config',
-            'value', array('course' => $this->course->id, 'name' => 'enable'));
+            'value', array('course' => $this->course->id, 'name' => 'recompletiontype'));
 
         if (!$this->columns) {
             $onerow = $DB->get_record_sql("SELECT {$this->sql->fields} FROM {$this->sql->from} WHERE {$this->sql->where}",

--- a/classes/task/check_recompletion.php
+++ b/classes/task/check_recompletion.php
@@ -60,7 +60,7 @@ class check_recompletion extends \core\task\scheduled_task {
 
         $sql = "SELECT cc.userid, cc.course
             FROM {course_completions} cc
-            JOIN {local_recompletion_config} r ON r.course = cc.course AND r.name = 'enable' AND r.value = '1'
+            JOIN {local_recompletion_config} r ON r.course = cc.course AND r.name = 'recompletiontype' AND r.value = 'period'
             JOIN {local_recompletion_config} r2 ON r2.course = cc.course AND r2.name = 'recompletionduration'
             JOIN {course} c ON c.id = cc.course
             WHERE c.enablecompletion = ".COMPLETION_ENABLED." AND cc.timecompleted > 0 AND

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -679,5 +679,20 @@ function xmldb_local_recompletion_upgrade($oldversion) {
         upgrade_plugin_savepoint(true, 2023092022, 'local', 'recompletion');
     }
 
+    if ($oldversion < 2023092801) {
+        // Enable setting moved to a select option.
+        // Multiple sql calls for best cross db compatible option.
+        $sql = "UPDATE {local_recompletion_config} SET name = 'recompletiontype' WHERE name = 'enable' and value = '1'";
+        $DB->execute($sql);
+        $sql = "UPDATE {local_recompletion_config} SET value = 'period' WHERE name = 'recompletiontype' and value = '1'";
+        $DB->execute($sql);
+        // Clean up old empty enabled/disabled config settings.
+        $DB->delete_records('local_recompletion_config', ['name' => 'enable']);
+
+        // Recompletion savepoint reached.
+        upgrade_plugin_savepoint(true, 2023092801, 'local', 'recompletion');
+
+    }
+
     return true;
 }

--- a/lang/en/local_recompletion.php
+++ b/lang/en/local_recompletion.php
@@ -25,8 +25,15 @@
 $string['pluginname'] = 'Course recompletion';
 $string['recompletion'] = 'recompletion';
 $string['editrecompletion'] = 'Edit course recompletion settings';
-$string['enablerecompletion'] = 'Enable recompletion';
-$string['enablerecompletion_help'] = 'The recompletion plugin allows a course completion details to be reset after a defined period.';
+$string['recompletiontype:period'] = 'Period';
+$string['recompletiontype:ondemand'] = 'On demand';
+$string['recompletiontype:disabled'] = 'Disabled';
+$string['recompletiontype'] = 'Recompletion type';
+$string['recompletiontype_help'] = 'Determines how user completion results will be reset for new courses.
+
+* Disabled - disables this feature.
+* Period - allows the teacher to define an automated recompletion based on the users course completion date.
+* On demand - allows the teacher to manually reset individual users as required.';
 $string['recompletionrange'] = 'Recompletion period';
 $string['recompletionrange_help'] = 'Set the period of time before a users completion results are reset.';
 $string['recompletionsettingssaved'] = 'Recompletion settings saved';

--- a/lib.php
+++ b/lib.php
@@ -37,7 +37,7 @@ function local_recompletion_extend_navigation_course($navigation, $course, $cont
     }
 
     if (has_capability('local/recompletion:resetmycompletion', $context)) {
-        $enabled = $DB->get_field('local_recompletion_config', 'value', ['name' => 'enable', 'course' => $course->id]);
+        $enabled = $DB->get_field('local_recompletion_config', 'value', ['name' => 'recompletiontype', 'course' => $course->id]);
         if (!empty($enabled)) {
             $url = new moodle_url('/local/recompletion/resetcompletion.php', array('id' => $course->id));
             $name = get_string('resetmycompletion', 'local_recompletion');

--- a/recompletion.php
+++ b/recompletion.php
@@ -69,7 +69,7 @@ if (!empty(get_config('local_recompletion', 'forcearchivecompletiondata'))) {
     }
 }
 
-$setnames = array('enable', 'recompletionduration', 'deletegradedata', 'archivecompletiondata',
+$setnames = array('recompletiontype', 'recompletionduration', 'deletegradedata', 'archivecompletiondata',
     'recompletionemailenable', 'recompletionemailsubject', 'recompletionemailbody',
     'recompletionemailbody_format', 'assignevent');
 
@@ -114,7 +114,7 @@ if ($form->is_cancelled()) {
             } else {
                 $DB->update_record('local_recompletion_config', $rc);
             }
-            if ($name == 'enable' && empty($value)) {
+            if ($name == 'recompletiontype' && empty($value)) {
                 // Don't overwrite any other settings when recompletion disabled.
                 break;
             }

--- a/resetcompletion.php
+++ b/resetcompletion.php
@@ -57,7 +57,7 @@ if ($USER->id <> $userid) {
 $config = $DB->get_records_menu('local_recompletion_config', array('course' => $course->id), '', 'name, value');
 $config = (object) $config;
 
-if (empty($config->enable)) {
+if (empty($config->recompletiontype)) {
     throw new moodle_exception('recompletionnotenabled', 'local_recompletion');
 }
 

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2023092022;
-$plugin->release   = 2023090800;
+$plugin->version   = 2023092801;
+$plugin->release   = 2023092801;
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->requires  = 2021051700; // Requires 3.11.
 $plugin->component = 'local_recompletion';


### PR DESCRIPTION
Some sites want to use recompletion without a duration at all, but the ability for a teacher to reset a specific user so they can recomplete a course. This swaps out the disable/enable feauture for a "recompletion type" field allowing the user to select from "disabled", "period" (reset based on a period) or "manual" - If the manual option is set, it allows the reset completion settings to be configured and the manual reset option on the report is shown.