### PR TITLE
issue #94: trigger recompletion on user un-enrolment

### DIFF
--- a/classes/observer.php
+++ b/classes/observer.php
@@ -14,14 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-/**
- * Event observers used in Urkund Plagiarism plugin.
- *
- * @package    local_recompletion
- * @author     Dan Marsden <dan@danmarsden.com>
- * @copyright  2020 Catalyst IT
- * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
- */
+namespace local_recompletion;
+
+defined('MOODLE_INTERNAL') || die;
+
+require_once($CFG->dirroot.'/local/recompletion/locallib.php');
 
 /**
  * Class local_recompletion_observer
@@ -30,7 +27,7 @@
  * @copyright 2020 Catalyst IT
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class local_recompletion_observer {
+class observer {
     /**
      * Observer function to handle the assessable_uploaded event in mod_assign.
      * @param \mod_assign\event\submission_graded $event
@@ -52,6 +49,31 @@ class local_recompletion_observer {
                 // If we already have a completion date, clear it first so that mark_complete works.
                 $ccompletion->timecompleted = null;
                 $ccompletion->mark_complete($event->timecreated);
+            }
+        }
+    }
+
+    /**
+     * Observer function to handle user un-enrolment.
+     * @param \core\event\user_enrolment_deleted $event
+     */
+    public static function user_enrolment_deleted(\core\event\user_enrolment_deleted $event) {
+        global $DB;
+
+        $userid = $event->relateduserid;
+        $course = $DB->get_record('course', ['id' => $event->courseid]);
+
+        $config = local_recompletion_get_config($course);
+        if (!empty($config->recompletiontype) && !empty($config->recompletionunenrolenable)) {
+            try {
+                $reset = new \local_recompletion\task\check_recompletion();
+                $errors = $reset->reset_user($userid, $course);
+            } catch (\Exception $exception) {
+                $errors = [$exception->getMessage()];
+            }
+
+            if (!empty($errors)) {
+                // TODO: implement a new completion_reset_failed event.
             }
         }
     }

--- a/classes/observer.php
+++ b/classes/observer.php
@@ -74,6 +74,8 @@ class observer {
 
             if (!empty($errors)) {
                 // TODO: implement a new completion_reset_failed event.
+                debugging('Completion reset failed for user ' . $userid .
+                    ' in course ' . $course->id . ' Errors: ' . implode(',', $errors), DEBUG_DEVELOPER);
             }
         }
     }

--- a/classes/recompletion_form.php
+++ b/classes/recompletion_form.php
@@ -79,6 +79,11 @@ class local_recompletion_recompletion_form extends moodleform {
         $mform->addHelpButton('recompletionemailenable', 'recompletionemailenable', 'local_recompletion');
         $mform->hideIf('recompletionemailenable', 'recompletiontype', 'eq', '');
 
+        $mform->addElement('checkbox', 'recompletionunenrolenable', get_string('recompletionunenrolenable', 'local_recompletion'));
+        $mform->setDefault('recompletionunenrolenable', $config->unenrolenable);
+        $mform->addHelpButton('recompletionunenrolenable', 'recompletionunenrolenable', 'local_recompletion');
+        $mform->hideIf('recompletionunenrolenable', 'recompletiontype', 'eq', '');
+
         // Email Notification settings.
         $mform->addElement('header', 'emailheader', get_string('emailrecompletiontitle', 'local_recompletion'));
         $mform->setExpanded('emailheader', false);

--- a/db/events.php
+++ b/db/events.php
@@ -28,6 +28,10 @@ defined('MOODLE_INTERNAL') || die();
 $observers = array (
     array(
         'eventname' => '\mod_assign\event\submission_graded',
-        'callback' => 'local_recompletion_observer::submission_graded'
+        'callback' => '\local_recompletion\observer::submission_graded'
+    ),
+    array(
+        'eventname' => '\core\event\user_enrolment_deleted',
+        'callback' => '\local_recompletion\observer::user_enrolment_deleted'
     ),
 );

--- a/lang/en/local_recompletion.php
+++ b/lang/en/local_recompletion.php
@@ -178,3 +178,5 @@ $string['customcertresetcertificates'] = 'Delete issued certificates';
 $string['customcertresetcertificatesverifywarn'] = 'Attention: Deleting the issued certificates, even if you archive them before the deletion, will result in the fact that issues certificates cannot be verified anymore in Moodle. Please only delete the certificates if this is acceptable for you.';
 $string['archivecustomcertcertificates'] = 'Archive issued certificates';
 $string['archivecustomcertcertificates_help'] = 'Should issued custom certificates be archived?';
+$string['recompletionunenrolenable'] = 'Reset completion on un-enrolment';
+$string['recompletionunenrolenable_help'] = 'Enable to trigger completion reset on user un-enrolment';

--- a/locallib.php
+++ b/locallib.php
@@ -121,6 +121,7 @@ function local_recompletion_get_config($course) {
         'assignevent' => null,
         'archivecompletiondata' => 0,
         'recompletionemailenable' => 0,
+        'recompletionunenrolenable' => 0,
         'recompletionemailbody' => '',
         'recompletionemailsubject' => '',
         'deletegradedata' => 0,
@@ -133,7 +134,7 @@ function local_recompletion_get_config($course) {
     // We could also combine the settings values so that the code calling it doesn't need to do this.
     if (!empty($dbconfig)) {
         foreach ($dbconfig as $key => $value) {
-            if ($config[$key] !== $value) {
+            if (!isset($config[$key]) || $config[$key] !== $value) {
                 $config[$key] = $value;
             }
         }

--- a/recompletion.php
+++ b/recompletion.php
@@ -70,7 +70,7 @@ if (!empty(get_config('local_recompletion', 'forcearchivecompletiondata'))) {
 }
 
 $setnames = array('recompletiontype', 'recompletionduration', 'deletegradedata', 'archivecompletiondata',
-    'recompletionemailenable', 'recompletionemailsubject', 'recompletionemailbody',
+    'recompletionemailenable', 'recompletionunenrolenable', 'recompletionemailsubject', 'recompletionemailbody',
     'recompletionemailbody_format', 'assignevent');
 
 $plugins = local_recompletion_get_supported_plugins();

--- a/settings.php
+++ b/settings.php
@@ -46,6 +46,10 @@ if ($hassiteconfig) {
         new lang_string('recompletionemailbody', 'local_recompletion'),
         new lang_string('recompletionemailbody_help', 'local_recompletion'), ''));
 
+    $settings->add(new admin_setting_configcheckbox('local_recompletion/unenrolenable',
+        new lang_string('recompletionunenrolenable', 'local_recompletion'),
+        new lang_string('recompletionunenrolenable_help', 'local_recompletion'), 0));
+
     $settings->add(new admin_setting_configcheckbox('local_recompletion/deletegradedata',
         new lang_string('deletegradedata', 'local_recompletion'),
         new lang_string('deletegradedata_help', 'local_recompletion'), 1));

--- a/tests/observer_test.php
+++ b/tests/observer_test.php
@@ -1,0 +1,140 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_recompletion;
+
+/**
+ * Class dialogue_test.
+ *
+ * @package    local_recompletion
+ * @copyright  2023 Dmitrii Metelkin
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ *
+ * @covers \local_recompletion\observer
+ */
+class observer_test extends \advanced_testcase {
+
+    /**
+     * Set up recompletion for a given course.
+     *
+     * @param int $courseid Course ID.
+     * @param array $config Recompletion config for a given course. If empty default values will be aplied.
+     */
+    protected function set_up_recompletion(int $courseid, array $config = []): void {
+        global $DB;
+
+        $DB->delete_records('local_recompletion_config', ['course' => $courseid]);
+
+        $defaultconfig = [
+            'recompletiontype' => 'ondemand',
+            'recompletionunenrolenable' => 1,
+            'archivecompletiondata' => 0,
+            'deletegradedata' => 1,
+            'recompletionemailenable' => 0,
+        ];
+
+        $config = array_merge($defaultconfig, $config);
+
+        foreach ($config as $name => $value) {
+            $DB->insert_record('local_recompletion_config', (object) [
+                'course' => $courseid,
+                'name' => $name,
+                'value' => $value,
+            ]);
+        }
+    }
+
+    /**
+     * Test completion is reset after a user is un-enrolled based on course settings.
+     */
+    public function test_recompletion_rest_after_user_is_unenrolled_based_on_settings() {
+        global $DB;
+
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        $enrol = enrol_get_plugin('self');
+
+        $course = $this->getDataGenerator()->create_course(['enablecompletion' => 1]);
+        $enrolinstance = $DB->get_record('enrol', ['courseid' => $course->id, 'enrol' => 'self'], '*', MUST_EXIST);
+
+        $user1 = $this->getDataGenerator()->create_user();
+        $user2 = $this->getDataGenerator()->create_user();
+
+        $studentrole = $DB->get_record('role', ['shortname' => 'student'], '*', MUST_EXIST);
+
+        // Enrol two users to a course.
+        $enrol->enrol_user($enrolinstance, $user1->id, $studentrole->id);
+        $enrol->enrol_user($enrolinstance, $user2->id, $studentrole->id);
+
+        // Make sure we trigger reset on un-enrolment.
+        $this->set_up_recompletion($course->id, ['recompletionunenrolenable' => 1]);
+
+        $compluser1 = new \completion_completion(['userid' => $user1->id, 'course' => $course->id]);
+        $compluser2 = new \completion_completion(['userid' => $user2->id, 'course' => $course->id]);
+
+        // Initially both users are not completed.
+        $this->assertFalse($compluser1->is_complete());
+        $this->assertFalse($compluser2->is_complete());
+
+        // Complete course for both.
+        $compluser1->mark_complete(0);
+        $compluser2->mark_complete(0);
+
+        $compluser1 = new \completion_completion(['userid' => $user1->id, 'course' => $course->id]);
+        $compluser2 = new \completion_completion(['userid' => $user2->id, 'course' => $course->id]);
+
+        $this->assertTrue($compluser1->is_complete());
+        $this->assertTrue($compluser2->is_complete());
+
+        // Unenrol user 1.
+        $enrol->unenrol_user($enrolinstance, $user1->id);
+
+        // Confirm that user 1 is not completed anymore as he's unenrolled form a course. User 2 should still be completed.
+        $compluser1 = new \completion_completion(['userid' => $user1->id, 'course' => $course->id]);
+        $compluser2 = new \completion_completion(['userid' => $user2->id, 'course' => $course->id]);
+        $this->assertFalse($compluser1->is_complete());
+        $this->assertTrue($compluser2->is_complete());
+
+        // Enrol back user 1 and confirm he's still not completed.
+        $enrol->enrol_user($enrolinstance, $user1->id, $studentrole->id);
+        $compluser1 = new \completion_completion(['userid' => $user1->id, 'course' => $course->id]);
+        $compluser2 = new \completion_completion(['userid' => $user2->id, 'course' => $course->id]);
+        $this->assertFalse($compluser1->is_complete());
+        $this->assertTrue($compluser2->is_complete());
+
+        // Now disable completion reset on un-enrolment.
+        $this->set_up_recompletion($course->id, ['recompletionunenrolenable' => 0]);
+
+        // Unenrol completed user 2.
+        $enrol->unenrol_user($enrolinstance, $user2->id);
+        $compluser1 = new \completion_completion(['userid' => $user1->id, 'course' => $course->id]);
+        $compluser2 = new \completion_completion(['userid' => $user2->id, 'course' => $course->id]);
+
+        // Confirm completion status is still completed for a user 2. User 1 should be without changes.
+        $this->assertFalse($compluser1->is_complete());
+        $this->assertTrue($compluser2->is_complete());
+
+        // Enrol back user 2.
+        $enrol->enrol_user($enrolinstance, $user2->id, $studentrole->id);
+        $compluser1 = new \completion_completion(['userid' => $user1->id, 'course' => $course->id]);
+        $compluser2 = new \completion_completion(['userid' => $user2->id, 'course' => $course->id]);
+
+        // Completion status should be still completed for a user 2. User 1 should be without changes.
+        $this->assertFalse($compluser1->is_complete());
+        $this->assertTrue($compluser2->is_complete());
+    }
+}

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2023101700;
-$plugin->release   = 2023101700;
+$plugin->version   = 2023101702;
+$plugin->release   = 2023101702;
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->requires  = 2022112806; // Requires 4.1
 $plugin->component = 'local_recompletion';


### PR DESCRIPTION
In this PR we add a new setting "Recompletion on un-enrolment". It's disabled by default. 

![image](https://github.com/danmarsden/moodle-local_recompletion/assets/4626431/9a48daf4-4d32-433d-a09b-b404167931b4)

To test:
1. Create a new course with bunch of users enrolled.
2. Enable completion for a course.
3. Set a course completion condition as a date in  the past. 
4. Complete course users by running core\task\completion_regular_task. 
5. Un-enrol a completed user and then re enrol back
6. Confirm that completion status is still "Completed"
7. Enable Recompletion on un-enrolment for the course
8.  Un-enrol completed user and then re enrol back
9. Confirm that completion status is  "Not completed"

 

