### PR TITLE
issue #135: do not display warning if 'Do nothing' is selected

### DIFF
--- a/classes/plugins/mod_certificate.php
+++ b/classes/plugins/mod_certificate.php
@@ -76,7 +76,7 @@ class mod_certificate {
         $mform->disabledIf('certificate', 'enable');
         $mform->disabledIf('archivecertificate', 'enable');
         $mform->hideIf('archivecertificate', 'certificate', 'noteq', LOCAL_RECOMPLETION_DELETE);
-        $mform->hideIf('certificateverifywarn', 'certificate', 'noteq', LOCAL_RECOMPLETION_DELETE);
+        $mform->hideIf('certificateverifywarngroup', 'certificate', 'noteq', LOCAL_RECOMPLETION_DELETE);
     }
 
     /**


### PR DESCRIPTION
After the change:

![image](https://github.com/danmarsden/moodle-local_recompletion/assets/4626431/73c10b57-1704-42e3-8549-bb3066f6bca9)

![image](https://github.com/danmarsden/moodle-local_recompletion/assets/4626431/7cd8ff6f-1818-4402-9776-742a1e5dd2d8)

