### PR TITLE
Issue #142: Get the config from local_recompletion_get_config

### DIFF
--- a/classes/task/check_recompletion.php
+++ b/classes/task/check_recompletion.php
@@ -122,8 +122,9 @@ class check_recompletion extends \core\task\scheduled_task {
             if (!isset($updateresettimes[$course->id]) && isset($user->schedule)) {
                 // Update next reset time.
                 $newconfig = new \stdClass();
-                if (isset($rc['nextresettime'])) {
-                    $newconfig->id = $rc['nextresettime']->id;
+                if (isset($config->nextresettime)) {
+                    $newconfig->id = $DB->get_field('local_recompletion_config', 'id',
+                        ['course' => $course->id, 'name' => 'nextresettime']);
                 }
                 $newconfig->course = $course->id;
                 $newconfig->name = 'nextresettime';

--- a/classes/task/check_recompletion.php
+++ b/classes/task/check_recompletion.php
@@ -111,8 +111,8 @@ class check_recompletion extends \core\task\scheduled_task {
 
             // Get recompletion config for this course (at most once).
             if (!isset($configs[$user->course])) {
-                $rc = $DB->get_records_list('local_recompletion_config', 'course', [$course->id], '', 'name, id, value');
-                $configs[$user->course] = (object) local_recompletion_get_data($rc);
+                $config = local_recompletion_get_config($course);
+                $configs[$user->course] = $config;
             }
             $config = $configs[$user->course];
 

--- a/locallib.php
+++ b/locallib.php
@@ -153,14 +153,18 @@ function local_recompletion_get_config($course) {
     // Ideally this would be picked up directly from settings or the override form.
     // Values if not set in the form are set to 0.
     $defaultconfig = [
-        'enable' => 0,
+        'recompletiontype' => '',
+        'recompletionduration' => 0,
+        'recompletionschedule' => '',
         'assignevent' => null,
         'archivecompletiondata' => 0,
         'recompletionemailenable' => 0,
         'recompletionunenrolenable' => 0,
         'recompletionemailbody' => '',
+        'recompletionemailbody_format' => FORMAT_HTML,
         'recompletionemailsubject' => '',
         'deletegradedata' => 0,
+        'nextresettime' => 0,
         'course' => null    // This isn't in the form.
     ];
 


### PR DESCRIPTION
Get the config from local_recompletion_get_config when executing check_recompletion task

This PR has been created to address: https://github.com/danmarsden/moodle-local_recompletion/issues/142