### PR TITLE
avoid "duplicate value x found in column 'userid'" in recompletion task

### DIFF
--- a/classes/task/check_recompletion.php
+++ b/classes/task/check_recompletion.php
@@ -50,7 +50,7 @@ class check_recompletion extends \core\task\scheduled_task {
 
         $now = time();
         // Period based recompletion users.
-        $sql = "SELECT cc.userid, cc.course, null as nextresettime
+        $sql = "SELECT cc.id, cc.userid, cc.course, null as nextresettime
                   FROM {course_completions} cc
                   JOIN {local_recompletion_config} r2 ON r2.course = cc.course AND r2.name = 'recompletionduration'
                   JOIN {local_recompletion_config} r3 ON r3.course = cc.course
@@ -62,7 +62,8 @@ class check_recompletion extends \core\task\scheduled_task {
         $users = $DB->get_records_sql($sql, [$now]);
 
         // Schedule based recompletion.
-        $sql = "SELECT cc.userid,
+        $sql = "SELECT cc.id,
+                       cc.userid,
                        cc.course,
                        r4.value as schedule,
                        cc.timecompleted,


### PR DESCRIPTION
A user who is to be reset in multiple courses within the same 'check_recompletion' task cycle will cause a "Did you remember to make the first column something unique in your call to get_records?" warning to be logged due their userid being returned in multiple records as the first column of the row. This results in one course being reset and the rest being skipped, which I imagine could be an issue for scheduled resets of courses that happen only once a year.

e.g.

    Execute scheduled task: Check for users that need to recomplete (local_recompletion\task\check_recompletion)
    ... started 12:28:26. Current memory use 17.6 MB.
    ++ Did you remember to make the first column something unique in your call to get_records? Duplicate value '5' found in column 'userid'. ++
    * line 1407 of /lib/dml/mysqli_native_moodle_database.php: call to debugging()
    * line 78 of /local/recompletion/classes/task/check_recompletion.php: call to mysqli_native_moodle_database->get_records_sql()
    * line 100 of /local/recompletion/classes/task/check_recompletion.php: call to local_recompletion\task\check_recompletion->get_user_courses_to_reset()
    * line 405 of /lib/classes/cron.php: call to local_recompletion\task\check_recompletion->execute()
    * line 198 of /admin/cli/scheduled_task.php: call to core\cron::run_inner_scheduled_task()
    ... used 50 dbqueries
    ... used 0.53339600563049 seconds
    Scheduled task complete: Check for users that need to recomplete (local_recompletion\task\check_recompletion)

This problem can be avoided by including `course_completions.id` as the first returned column.