### PR TITLE
Invalid default value for recompletiontype.

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -35,7 +35,9 @@ if ($hassiteconfig) {
     // Type of recompletion - range(duration) or schedule(absolute times, based on cron schedule).
     $settings->add(new admin_setting_configselect('local_recompletion/recompletiontype',
         new lang_string('recompletiontype', 'local_recompletion'),
-        new lang_string('recompletiontype_help', 'local_recompletion'), 'range', [
+        new lang_string('recompletiontype_help', 'local_recompletion'),
+        local_recompletion_recompletion_form::RECOMPLETION_TYPE_DISABLED,
+        [
             local_recompletion_recompletion_form::RECOMPLETION_TYPE_DISABLED => get_string(
                 'recompletiontype:disabled',
                 'local_recompletion'


### PR DESCRIPTION
Invalid default value for recompletiontype.

Before:
```
php admin/tool/behat/cli/run.php -vvv --colors --profile="chrome" --tags="@tool_admin_presets" --suite="default"

001 Scenario: Applied exported settings                               #admin/tool/admin_presets/tests/behat/apply_presets.feature:136
      When I choose "Review settings and apply" in the open action menu #admin/tool/admin_presets/tests/behat/apply_presets.feature:143
        Exception: debugging() message/s found:
        local_recompletion/recompletiontype setting has a wrong value!
002 Scenario: Export current settings                                   #admin/tool/admin_presets/tests/behat/export_settings.feature:20
      When I choose "Review settings and apply" in the open action menu #admin/tool/admin_presets/tests/behat/export_settings.feature:26
        Exception: debugging() message/s found:
        local_recompletion/recompletiontype setting has a wrong value!
```
After:
```
php admin/tool/behat/cli/run.php -vvv --colors --profile="chrome" --tags="@tool_admin_presets" --suite="default" --rerun
................................
2 scenarios (2 passed)
32 steps (32 passed)

```