### PR TITLE
notification setting to determine who gets recompletion message

### DIFF
--- a/classes/recompletion_form.php
+++ b/classes/recompletion_form.php
@@ -34,6 +34,15 @@ class local_recompletion_recompletion_form extends moodleform {
     /** @var string */
     const RECOMPLETION_TYPE_SCHEDULE = 'schedule';
 
+    /** @var string */
+    const RECOMPLETION_NOTIFY_COMPLETED_USERS = 'completed';
+
+    /** @var string */
+    const RECOMPLETION_NOTIFY_ENROLLED_USERS = 'enrolled';
+
+    /** @var string */
+    const RECOMPLETION_NOTIFY_ACTIVE_ENROLLED_USERS = 'activeenrolled';
+
     /**
      * Defines the form fields.
      */
@@ -71,6 +80,15 @@ class local_recompletion_recompletion_form extends moodleform {
         $mform->setDefault('recompletionemailenable', $config->emailenable);
         $mform->addHelpButton('recompletionemailenable', 'recompletionemailenable', 'local_recompletion');
         $mform->hideIf('recompletionemailenable', 'recompletiontype', 'eq', '');
+
+        $mform->addElement('select', 'recompletionnotify', get_string('recompletionnotify', 'local_recompletion'), [
+            self::RECOMPLETION_NOTIFY_COMPLETED_USERS => get_string('recompletionnotify:completed', 'local_recompletion'),
+            self::RECOMPLETION_NOTIFY_ENROLLED_USERS => get_string('recompletionnotify:enrolled', 'local_recompletion'),
+            self::RECOMPLETION_NOTIFY_ACTIVE_ENROLLED_USERS => get_string('recompletionnotify:activeenrolled', 'local_recompletion'),
+        ]);
+        $mform->setDefault('recompletionnotify', $config->recompletionnotify ?? '');
+        $mform->addHelpButton('recompletionnotify', 'recompletionnotify', 'local_recompletion');
+        $mform->disabledIf('recompletionnotify', 'recompletionemailenable', 'notchecked');
 
         $mform->addElement('checkbox', 'recompletionunenrolenable', get_string('recompletionunenrolenable', 'local_recompletion'));
         $mform->setDefault('recompletionunenrolenable', $config->unenrolenable);

--- a/classes/task/check_recompletion.php
+++ b/classes/task/check_recompletion.php
@@ -295,18 +295,14 @@ class check_recompletion extends \core\task\scheduled_task {
 
         // Determine if user should be notified.
         if ($config->recompletionemailenable) {
-            // If notifications enabled and user has a completion record, notify user.
+            // If user has a completion record, notify user.
             if ($config->recompletionnotify == 'completed') {
                 $this->notify_user($userid, $course, $config);
-            }
-            // If user has an enrollment (active or suspended), notify user.
-            else if ($config->recompletionnotify == 'enrolled') {
+            } else if ($config->recompletionnotify == 'enrolled') { // Active or suspended enrollment, notify user.
                 if (is_enrolled($context, $userid)) {
                     $this->notify_user($userid, $course, $config);
                 }
-            }
-            // If user has an active enrollment), notify user.
-            else if ($config->recompletionnotify == 'activeenrolled') {
+            } else if ($config->recompletionnotify == 'activeenrolled') { // Active enrollment only, notify user.
                 if (is_enrolled($context, $userid, '', true)) {
                     $this->notify_user($userid, $course, $config);
                 }

--- a/classes/task/check_recompletion.php
+++ b/classes/task/check_recompletion.php
@@ -293,20 +293,20 @@ class check_recompletion extends \core\task\scheduled_task {
 
         $context = \context_course::instance($course->id);
 
-        //Determine if user should be notified.
+        // Determine if user should be notified.
         if ($config->recompletionemailenable) {
             // If notifications enabled and user has a completion record, notify user.
             if ($config->recompletionnotify == 'completed') {
                 $this->notify_user($userid, $course, $config);
             }
             // If user has an enrollment (active or suspended), notify user.
-            elseif ($config->recompletionnotify == 'enrolled') {
+            else if ($config->recompletionnotify == 'enrolled') {
                 if (is_enrolled($context, $userid)) {
                     $this->notify_user($userid, $course, $config);
                 }
             }
             // If user has an active enrollment), notify user.
-            elseif ($config->recompletionnotify == 'activeenrolled') {
+            else if ($config->recompletionnotify == 'activeenrolled') {
                 if (is_enrolled($context, $userid, '', true)) {
                     $this->notify_user($userid, $course, $config);
                 }

--- a/classes/task/check_recompletion.php
+++ b/classes/task/check_recompletion.php
@@ -198,10 +198,6 @@ class check_recompletion extends \core\task\scheduled_task {
     protected function notify_user($userid, $course, $config) {
         global $DB, $CFG;
 
-        if (!$config->recompletionemailenable) {
-            return;
-        }
-
         $userrecord = $DB->get_record('user', ['id' => $userid]);
         $context = \context_course::instance($course->id);
         $from = get_admin();
@@ -295,11 +291,29 @@ class check_recompletion extends \core\task\scheduled_task {
             }
         }
 
-        // Now notify user.
-        $this->notify_user($userid, $course, $config);
+        $context = \context_course::instance($course->id);
+
+        //Determine if user should be notified.
+        if ($config->recompletionemailenable) {
+            // If notifications enabled and user has a completion record, notify user.
+            if ($config->recompletionnotify == 'completed') {
+                $this->notify_user($userid, $course, $config);
+            }
+            // If user has an enrollment (active or suspended), notify user.
+            elseif ($config->recompletionnotify == 'enrolled') {
+                if (is_enrolled($context, $userid)) {
+                    $this->notify_user($userid, $course, $config);
+                }
+            }
+            // If user has an active enrollment), notify user.
+            elseif ($config->recompletionnotify == 'activeenrolled') {
+                if (is_enrolled($context, $userid, '', true)) {
+                    $this->notify_user($userid, $course, $config);
+                }
+            }
+        }
 
         // Trigger completion reset event for this user.
-        $context = \context_course::instance($course->id);
         $event = \local_recompletion\event\completion_reset::create(
             [
                 'objectid'      => $course->id,

--- a/lang/en/local_recompletion.php
+++ b/lang/en/local_recompletion.php
@@ -51,6 +51,16 @@ $string['completionnotenabled'] = 'Completion is not enabled in this course';
 $string['recompletionnotenabledincourse'] = 'Recompletion is not enabled in courseid: {$a}';
 $string['recompletionemailenable'] = 'Send recompletion message';
 $string['recompletionemailenable_help'] = 'Enable email messaging to notifiy users that recompletion is required';
+
+$string['recompletionnotify:completed'] = 'Send to all users (with a completion record)';
+$string['recompletionnotify:enrolled'] = 'Send to all users (with an enrollment)';
+$string['recompletionnotify:activeenrolled'] = 'Send to all users (with an active enrollment)';
+$string['recompletionnotify'] = 'Recompletion user notification';
+$string['recompletionnotify_help'] = 'Determines which users are notified of recompletion.
+* Send to all users (with a completion record) - If a course completion record exists for a user, they will be notified.
+* Send to all users (with an enrollment) - If a user is enrolled (active, suspended, etc) in the course, they will be notified.
+* Send to all users (with an active enrollment) - If a user is actively enrolled, they will be notified.';
+
 $string['recompletionemailsubject'] = 'Recompletion message subject';
 $string['recompletionemailsubject_help'] = 'A custom recompletion email subject may be added as plain text
 

--- a/recompletion.php
+++ b/recompletion.php
@@ -76,6 +76,7 @@ $setnames = [
     'deletegradedata',
     'archivecompletiondata',
     'recompletionemailenable',
+    'recompletionnotify',
     'recompletionunenrolenable',
     'recompletionemailsubject',
     'recompletionemailbody',

--- a/settings.php
+++ b/settings.php
@@ -66,6 +66,23 @@ if ($hassiteconfig) {
         new lang_string('recompletionemailenable', 'local_recompletion'),
         new lang_string('recompletionemailenable_help', 'local_recompletion'), 1));
 
+        $settings->add(new admin_setting_configselect('local_recompletion/recompletionnotify',
+        new lang_string('recompletionnotify', 'local_recompletion'),
+        new lang_string('recompletionnotify_help', 'local_recompletion'), 'range', [
+            local_recompletion_recompletion_form::RECOMPLETION_NOTIFY_COMPLETED_USERS => get_string(
+                'recompletionnotify:completed',
+                'local_recompletion',
+            ),
+            local_recompletion_recompletion_form::RECOMPLETION_NOTIFY_ENROLLED_USERS => get_string(
+                'recompletionnotify:enrolled',
+                'local_recompletion',
+            ),
+            local_recompletion_recompletion_form::RECOMPLETION_NOTIFY_ACTIVE_ENROLLED_USERS => get_string(
+                'recompletionnotify:activeenrolled',
+                'local_recompletion',
+            ),
+        ]));
+
     $settings->add(new admin_setting_configtext('local_recompletion/emailsubject',
         new lang_string('recompletionemailsubject', 'local_recompletion'),
         new lang_string('recompletionemailsubject_help', 'local_recompletion'), '', PARAM_TEXT));


### PR DESCRIPTION
Add a new notification setting to determine which user gets a recompletion notification. Original enable/disable email notification stays the same, but the following additional 'levels' are added:

* Send to all users (with a completion record) - If a course completion record exists for a user, they will be notified.
* Send to all users (with an enrollment) - If a user is enrolled (active, suspended, etc) in the course, they will be notified.
* Send to all users (with an active enrollment) - If a user is actively enrolled, they will be notified.

Fixes #153 