### PR TITLE
Privacy provider test error

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -430,14 +430,15 @@ class provider implements
         $courseid = $context->instanceid;
 
         $params = array('course' => $courseid);
+        $paramsid = array('courseid' => $courseid);
         $DB->delete_records('local_recompletion_cc', $params);
         $DB->delete_records('local_recompletion_cc_cc', $params);
         $DB->delete_records('local_recompletion_cmc', $params);
         $DB->delete_records('local_recompletion_cmv', $params);
         $DB->delete_records('local_recompletion_qa', $params);
         $DB->delete_records('local_recompletion_qg', $params);
-        $DB->delete_records('local_recompletion_ssv', $params);
-        $DB->delete_records('local_recompletion_sa', $params);
+        $DB->delete_records('local_recompletion_ssv', $paramsid);
+        $DB->delete_records('local_recompletion_sa', $paramsid);
         $DB->delete_records('local_recompletion_qr', $params);
         $DB->delete_records('local_recompletion_cha', $params);
         $DB->delete_records('local_recompletion_hvp', $params);


### PR DESCRIPTION
Seeing this error on running the main Moodle unit tests with the MOODLE_403_STABLE branch installed:

```
1) tool_dataprivacy\expired_contexts_test::test_orphaned_records_are_cleared
Unexpected debugging() call detected.
Debugging: Field "course" does not exist in table "local_recompletion_ssv"
* line 2036 of /lib/dml/moodle_database.php: call to moodle_database->where_clause()
* line 439 of /local/recompletion/classes/privacy/provider.php: call to moodle_database->delete_records()
* line 8292 of /lib/moodlelib.php: call to local_recompletion\privacy\provider::delete_data_for_all_users_in_context()
* line 578 of /privacy/classes/manager.php: call to component_class_callback()
* line 611 of /privacy/classes/manager.php: call to core_privacy\manager::component_class_callback()
* line 492 of /privacy/classes/manager.php: call to core_privacy\manager->handled_component_class_callback()
* line 440 of /admin/tool/dataprivacy/classes/expired_contexts_manager.php: call to core_privacy\manager->delete_data_for_all_users_in_context()
* line 388 of /admin/tool/dataprivacy/classes/expired_contexts_manager.php: call to tool_dataprivacy\expired_contexts_manager->delete_expired_context()
* line 2052 of /admin/tool/dataprivacy/tests/expired_contexts_test.php: call to tool_dataprivacy\expired_contexts_manager->process_approved_deletions()
* line 1548 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to tool_dataprivacy\expired_contexts_test->test_orphaned_records_are_cleared()
```

It looks like it's because a couple of the tables have a column called courseid rather than course.