### PR TITLE
Issue #77: Add Quiz Option to Reset User Overrides

### DIFF
--- a/classes/plugins/mod_quiz.php
+++ b/classes/plugins/mod_quiz.php
@@ -62,9 +62,15 @@ class mod_quiz {
             get_string('archive', 'local_recompletion'));
         $mform->setDefault('archivequiz', $config->archivequiz);
 
+        $mform->addElement('checkbox', 'resetquizoverride',
+            get_string('resetquizoverride', 'local_recompletion'));
+        $mform->setDefault('resetquizoverride', $config->resetquizoverride);
+
         $mform->disabledIf('quiz', 'enable', 'notchecked');
         $mform->disabledIf('archivequiz', 'enable', 'notchecked');
+        $mform->disabledIf('resetquizoverride', 'enable', 'notchecked');
         $mform->hideIf('archivequiz', 'quiz', 'noteq', LOCAL_RECOMPLETION_DELETE);
+        $mform->hideIf('resetquizoverride', 'quiz', 'noteq', LOCAL_RECOMPLETION_DELETE);
     }
 
     /**
@@ -83,6 +89,9 @@ class mod_quiz {
 
         $settings->add(new \admin_setting_configcheckbox('local_recompletion/archivequiz',
             new lang_string('archivequiz', 'local_recompletion'), '', 1));
+
+        $settings->add(new \admin_setting_configcheckbox('local_recompletion/resetquizoverride',
+            new lang_string('resetquizoverride', 'local_recompletion'), '', 0));
     }
 
     /**
@@ -112,6 +121,9 @@ class mod_quiz {
                     $quizgrades[$qid]->course = $course->id;
                 }
                 $DB->insert_records('local_recompletion_qg', $quizgrades);
+            }
+            if ($config->resetquizoverride) {
+                $DB->delete_records_select('quiz_overrides', $selectsql, $params);
             }
             $DB->delete_records_select('quiz_attempts', $selectsql, $params);
             $DB->delete_records_select('quiz_grades', $selectsql, $params);

--- a/lang/en/local_recompletion.php
+++ b/lang/en/local_recompletion.php
@@ -195,6 +195,7 @@ $string['modifycompletiondates'] = 'Modify course completion dates';
 $string['assignevent'] = 'Update course completion on grade change';
 $string['defaultsettings'] = 'Recompletion default settings';
 $string['archivequiz'] = 'Archive old quiz attempts';
+$string['resetquizoverride'] = 'Reset quiz user overrides';
 $string['archivequestionnaire'] = 'Archive old questionnaire attempts';
 $string['archivescorm'] = 'Archive old SCORM attempts';
 $string['resetlti'] = 'Reset LTI grades';

--- a/recompletion.php
+++ b/recompletion.php
@@ -82,6 +82,7 @@ $setnames = [
     'recompletionemailbody_format',
     'assignevent',
     'nextresettime',
+    'resetquizoverride',
 ];
 
 $plugins = local_recompletion_get_supported_plugins();


### PR DESCRIPTION
Adds an option to remove quiz user overrides when deleting existing attempts. This is primarily intended to allow removing extra attempts but is applicable to all overrides since it deletes the `quiz_overrides` for the user.

**Global Settings Page:**
![global-settings](https://github.com/danmarsden/moodle-local_recompletion/assets/100257316/bfaaeda5-214c-42ad-875c-a85f081ff943)

**Course Settings Page:**
![course-settings](https://github.com/danmarsden/moodle-local_recompletion/assets/100257316/bd6ab812-ae32-47d5-b5f6-104b8d2cbe01)

Closes #77