### PR TITLE
exposes 'local_recompletion_reset_course' as webservice

### DIFF
--- a/db/services.php
+++ b/db/services.php
@@ -36,3 +36,17 @@ $functions = [
         'capabilities'  => 'local/recompletion:manage'
     ],
 ];
+
+
+$services = array(
+    'Recompletion Service' => array(
+        'functions' => array(           
+            'local_recompletion_reset_course',
+        ),
+        'restrictedusers' => 1,
+        'enabled' => 1,
+        'shortname' => 'reset_course',
+        'downloadfiles' => 0,
+        'uploadfiles'  => 0
+    )
+);

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2024071103;
-$plugin->release   = 2024071103;
+$plugin->version   = 2024071903;
+$plugin->release   = 2024071903;
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->requires  = 2023100900; // Requires 4.3.
 $plugin->component = 'local_recompletion';


### PR DESCRIPTION
local_recompletion_reset_course was added as external service but since it was not declared as a service which is required iin case you want to call this service through a webservice call 
