### PR TITLE
Fix #188 - allow re-use of existing function which requires sesskey.

### DIFF
--- a/classes/plugins/mod_assign.php
+++ b/classes/plugins/mod_assign.php
@@ -102,7 +102,8 @@ class mod_assign {
                 $cm = get_coursemodule_from_instance('assign', $assign->id);
                 $context = \context_module::instance($cm->id);
                 if (has_capability('mod/assign:grade', $context)) {
-                    // Assign add_attempt() is protected - use reflection so we don't have to write our own.
+                    // Assign add_attempt() is protected and requires sesskey, use reflection so we don't have to write our own.
+                    $_POST['sesskey'] = sesskey();
                     $r = new \ReflectionMethod('assign', 'add_attempt');
                     $r->setAccessible(true);
                     $r->invoke(new \assign($context, $cm, $course), $userid);


### PR DESCRIPTION
This is a draft PR to fix #188 - it's a bit hacky but I suspect it's the only way if we want to re-use the core assignment functions.