### PR TITLE
Fix #290: Fix Custom Reports Entities for Moodle 4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,36 +8,38 @@ Branches
 --------
 The following git branches are currently supported:
 
-| Moodle version     | Branch      |
-| ----------------- | ----------- |
+| Moodle version   | Branch            |
+|------------------|-------------------|
 | Moodle 4.1 - 4.2 | MOODLE_401_STABLE |
-| Moodle 4.3 | MOODLE_403_STABLE |
-| Moodle 4.5+ | MOODLE_405_STABLE |
+| Moodle 4.3       | MOODLE_403_STABLE |
+| Moodle 4.5+      | MOODLE_405_STABLE |
 
-This plugin adds course level settings for recompletion - clearing all course, activity completion and all other related moodle plugins data for a user based on the duration set notifying the student they need to return to the course and recomplete it.
+This plugin adds course level settings for recompletion - clearing all course, activity completion and all other related moodle plugins data for a user based on the duration set
+notifying the student they need to return to the course and recomplete it.
 
 This plugin could be used to facilitate annual re-certification.
 
 The following information is cleared from the course during recompletion:
+
 * All activity grades cleared (and saved to standard grade history tables.)
 * All activity completion and course completion flags removed. (with the option to archive this information)
 
 The following activities have extra support:
+
 1) Quiz
-You can choose to delete all existing quiz attempt data with the option to archive the information or,
-you can keep the existing attempts and give the student the ability to add new attempts.
+   You can choose to delete all existing quiz attempt data with the option to archive the information or,
+   you can keep the existing attempts and give the student the ability to add new attempts.
 
 2) SCORM
-You can choose to delete all existing SCORM attempt data with the option to archive the information.
+   You can choose to delete all existing SCORM attempt data with the option to archive the information.
 
 3) Assignment
-You can choose to give the student another attempt (if the assignment is configured to allow reopening and the maximum number of attempts has not been reached.
+   You can choose to give the student another attempt (if the assignment is configured to allow reopening and the maximum number of attempts has not been reached.
 
 If a user has already completed the course, and a teacher performs a grading action on an assignment, you can choose to have the course completion date updated at the same time.
 
 Other plugins that store user data will have the activity completion data, and all related data reset, but may require manual intervention as they are not yet supported fully.
 Get in touch privately if you would like to fund support for other activities with user data.
-
 
 For more documentation on this plugin please see:
 https://github.com/danmarsden/moodle-local_recompletion/wiki

--- a/backup/moodle2/backup_local_recompletion_plugin.class.php
+++ b/backup/moodle2/backup_local_recompletion_plugin.class.php
@@ -37,34 +37,33 @@ class backup_local_recompletion_plugin extends backup_local_plugin {
      * Returns the format information to attach to course element.
      */
     protected function define_course_plugin_structure() {
-
         // Are we including usercompletion info in this backup.
         $usercompletion = $this->get_setting_value('userscompletion');
 
         $plugin = $this->get_plugin_element();
         $recompletion = new backup_nested_element($this->get_recommended_name());
 
-        $recompletiondata = new backup_nested_element('recompletion_config', null, array(
-            'course', 'name', 'value'));
+        $recompletiondata = new backup_nested_element('recompletion_config', null, [
+                'course', 'name', 'value']);
 
         // Handle Historical course completions.
         $cc = new backup_nested_element('course_completion');
 
-        $coursecompletions = new backup_nested_element('coursecompletion', array('id'), array(
-            'userid', 'course', 'timeenrolled', 'timestarted', 'timecompleted', 'reaggregate'
-        ));
+        $coursecompletions = new backup_nested_element('coursecompletion', ['id'], [
+                'userid', 'course', 'timeenrolled', 'timestarted', 'timecompleted', 'reaggregate',
+        ]);
 
         // Now Handle historical course_completion_crit_compl table.
         $criteriacompletions = new backup_nested_element('course_completion_crit_completions');
 
-        $criteriacomplete = new backup_nested_element('course_completion_crit_compl', array('id'), array(
-            'criteriaid', 'userid', 'gradefinal', 'unenrolled', 'timecompleted'
-        ));
+        $criteriacomplete = new backup_nested_element('course_completion_crit_compl', ['id'], [
+                'criteriaid', 'userid', 'gradefinal', 'unenrolled', 'timecompleted',
+        ]);
 
         $completions = new backup_nested_element('completions');
 
-        $completion = new backup_nested_element('completion', array('id'), array(
-            'userid', 'completionstate', 'viewed', 'timemodified', 'coursemoduleid', 'course'));
+        $completion = new backup_nested_element('completion', ['id'], [
+                'userid', 'completionstate', 'viewed', 'timemodified', 'coursemoduleid', 'course']);
 
         $plugin->add_child($recompletion);
         $recompletion->add_child($recompletiondata);
@@ -76,14 +75,14 @@ class backup_local_recompletion_plugin extends backup_local_plugin {
         $completions->add_child($completion);
 
         // Set source to populate the data.
-        $recompletiondata->set_source_table('local_recompletion_config', array(
-            'course' => backup::VAR_PARENTID));
+        $recompletiondata->set_source_table('local_recompletion_config', [
+                'course' => backup::VAR_PARENTID]);
 
         // Only include the archive info if usercompletion is also being saved to backup.
         if ($usercompletion) {
-            $coursecompletions->set_source_table('local_recompletion_cc', array('course' => backup::VAR_COURSEID));
-            $criteriacomplete->set_source_table('local_recompletion_cc_cc', array('course' => backup::VAR_COURSEID));
-            $completion->set_source_table('local_recompletion_cmc', array('course' => backup::VAR_COURSEID));
+            $coursecompletions->set_source_table('local_recompletion_cc', ['course' => backup::VAR_COURSEID]);
+            $criteriacomplete->set_source_table('local_recompletion_cc_cc', ['course' => backup::VAR_COURSEID]);
+            $completion->set_source_table('local_recompletion_cmc', ['course' => backup::VAR_COURSEID]);
         }
         $coursecompletions->annotate_ids('user', 'userid');
         $criteriacomplete->annotate_ids('user', 'userid');
@@ -94,22 +93,23 @@ class backup_local_recompletion_plugin extends backup_local_plugin {
         // Now deal with Quiz Archive tables.
         $quizgrades = new backup_nested_element('quizgrades');
 
-        $grade = new backup_nested_element('grade', array('id'), array(
-            'userid', 'quiz', 'gradeval', 'timemodified', 'course'));
+        $grade = new backup_nested_element('grade', ['id'], [
+                'userid', 'quiz', 'gradeval', 'timemodified', 'course']);
 
         $quizattempts = new backup_nested_element('quizattempts');
 
-        $attempt = new backup_nested_element('attempt', array('id'), array(
-            'userid', 'attempt', 'uniqueid', 'layout', 'currentpage', 'preview', 'quiz',
-            'state', 'timestart', 'timefinish', 'timemodified', 'timemodifiedoffline', 'timecheckstate', 'sumgrades', 'course'));
+        $attempt = new backup_nested_element('attempt', ['id'], [
+                'userid', 'attempt', 'uniqueid', 'layout', 'currentpage', 'preview', 'quiz',
+                'state', 'timestart', 'timefinish', 'timemodified', 'timemodifiedoffline', 'timecheckstate', 'sumgrades',
+                'course']);
 
         $recompletion->add_child($quizgrades);
         $quizgrades->add_child($grade);
         $recompletion->add_child($quizattempts);
         $quizattempts->add_child($attempt);
         if ($usercompletion) {
-            $attempt->set_source_table('local_recompletion_qa', array('course' => backup::VAR_COURSEID));
-            $grade->set_source_table('local_recompletion_qg', array('course' => backup::VAR_COURSEID));
+            $attempt->set_source_table('local_recompletion_qa', ['course' => backup::VAR_COURSEID]);
+            $grade->set_source_table('local_recompletion_qg', ['course' => backup::VAR_COURSEID]);
         }
 
         $attempt->annotate_ids('user', 'userid');
@@ -118,66 +118,67 @@ class backup_local_recompletion_plugin extends backup_local_plugin {
         // Now deal with SCORM archive tables.
         $scormattempts = new backup_nested_element('scormattempts');
 
-        $scormattempt = new backup_nested_element('scormattempt', array('id'), array(
-            'scormid', 'userid', 'attempt', 'courseid'));
+        $scormattempt = new backup_nested_element('scormattempt', ['id'], [
+                'scormid', 'userid', 'attempt', 'courseid']);
 
         $recompletion->add_child($scormattempts);
         $scormattempts->add_child($scormattempt);
 
         if ($usercompletion) {
-            $scormattempt->set_source_table('local_recompletion_sa', array('courseid' => backup::VAR_COURSEID));
+            $scormattempt->set_source_table('local_recompletion_sa', ['courseid' => backup::VAR_COURSEID]);
         }
         $scormattempt->annotate_ids('user', 'userid');
 
         $scotracks = new backup_nested_element('scormtracks');
 
-        $scotrack = new backup_nested_element('sco_track', array('id'), array(
-            'scoid', 'attemptid', 'elementid', 'value', 'courseid', 'timemodified'));
+        $scotrack = new backup_nested_element('sco_track', ['id'], [
+                'scoid', 'attemptid', 'elementid', 'value', 'courseid', 'timemodified']);
 
         $recompletion->add_child($scotracks);
         $scotracks->add_child($scotrack);
 
         if ($usercompletion) {
-            $scotrack->set_source_table('local_recompletion_ssv', array('courseid' => backup::VAR_COURSEID));
+            $scotrack->set_source_table('local_recompletion_ssv', ['courseid' => backup::VAR_COURSEID]);
         }
         // Now deal with choice archive tables.
         $choiceanswers = new backup_nested_element('choiceanswers');
 
-        $choiceanswer = new backup_nested_element('choiceanswer', array('id'), array(
-            'choiceid', 'userid', 'optionid', 'timemodified', 'choice'));
+        $choiceanswer = new backup_nested_element('choiceanswer', ['id'], [
+                'choiceid', 'userid', 'optionid', 'timemodified', 'choice']);
 
         $recompletion->add_child($choiceanswers);
         $choiceanswers->add_child($choiceanswer);
 
         if ($usercompletion) {
-            $choiceanswer->set_source_table('local_recompletion_cha', array('course' => backup::VAR_COURSEID));
+            $choiceanswer->set_source_table('local_recompletion_cha', ['course' => backup::VAR_COURSEID]);
         }
         $choiceanswer->annotate_ids('user', 'userid');
 
         // Now deal with hvp archive tables.
         $hvpattempts = new backup_nested_element('hvpattempts');
-        $hvpattempt = new backup_nested_element('hvpattempt', array('id'), array(
-            'user_id', 'hvp_id', 'sub_content_id', 'data_id', 'data', 'preloaded', 'delete_on_content_change', 'course'));
+        $hvpattempt = new backup_nested_element('hvpattempt', ['id'], [
+                'user_id', 'hvp_id', 'sub_content_id', 'data_id', 'data', 'preloaded', 'delete_on_content_change', 'course']);
 
         $recompletion->add_child($hvpattempts);
         $hvpattempts->add_child($hvpattempt);
 
         if ($usercompletion) {
-            $hvpattempt->set_source_table('local_recompletion_hvp', array('course' => backup::VAR_COURSEID));
+            $hvpattempt->set_source_table('local_recompletion_hvp', ['course' => backup::VAR_COURSEID]);
         }
         $hvpattempt->annotate_ids('user', 'user_id');
 
         // Now deal with h5p table.
         $h5ps = new backup_nested_element('h5ps');
-        $h5p = new backup_nested_element('h5p', array('id'), array(
-            'originalattemptid', 'h5pactivityid', 'userid', 'timecreated', 'timemodified',
-            'rawscore', 'maxscore', 'scaled', 'duration', 'completion', 'success', 'course'));
+        $h5p = new backup_nested_element('h5p', ['id'], [
+                'originalattemptid', 'h5pactivityid', 'userid', 'timecreated', 'timemodified',
+                'rawscore', 'maxscore', 'scaled', 'duration', 'completion', 'success', 'course']);
 
         // Now deal with h5p results table.
         $h5presults = new backup_nested_element('h5presults');
-        $h5presult = new backup_nested_element('h5presult', array('id'), array(
-            'attemptid', 'subcontent', 'timecreated', 'interactiontype', 'description',
-            'correctpattern', 'response', 'additionals', 'rawscore', 'maxscore', 'duration', 'completion', 'success', 'course'));
+        $h5presult = new backup_nested_element('h5presult', ['id'], [
+                'attemptid', 'subcontent', 'timecreated', 'interactiontype', 'description',
+                'correctpattern', 'response', 'additionals', 'rawscore', 'maxscore', 'duration', 'completion', 'success',
+                'course']);
 
         $recompletion->add_child($h5ps);
         $h5ps->add_child($h5p);
@@ -185,10 +186,10 @@ class backup_local_recompletion_plugin extends backup_local_plugin {
         $h5presults->add_child($h5presult);
 
         if ($usercompletion) {
-            $h5p->set_source_table('local_recompletion_h5p', array('course' => backup::VAR_COURSEID));
+            $h5p->set_source_table('local_recompletion_h5p', ['course' => backup::VAR_COURSEID]);
             $h5presult->set_source_table(
-                'local_recompletion_h5pr',
-                array('course' => backup::VAR_COURSEID, 'attemptid' => backup::VAR_PARENTID)
+                    'local_recompletion_h5pr',
+                    ['course' => backup::VAR_COURSEID, 'attemptid' => backup::VAR_PARENTID]
             );
         }
 
@@ -196,90 +197,90 @@ class backup_local_recompletion_plugin extends backup_local_plugin {
 
         // Now deal with lesson archive tables.
         $lessonattempts = new backup_nested_element('lessonattempts');
-        $lessonattempt = new backup_nested_element('lessonattempt', array('id'), array(
-            'lessonid', 'pageid', 'userid', 'answerid', 'retry', 'correct', 'useranswer', 'timeseen', 'course'));
+        $lessonattempt = new backup_nested_element('lessonattempt', ['id'], [
+                'lessonid', 'pageid', 'userid', 'answerid', 'retry', 'correct', 'useranswer', 'timeseen', 'course']);
 
         $recompletion->add_child($lessonattempts);
         $lessonattempts->add_child($lessonattempt);
 
         if ($usercompletion) {
-            $lessonattempt->set_source_table('local_recompletion_la', array('course' => backup::VAR_COURSEID));
+            $lessonattempt->set_source_table('local_recompletion_la', ['course' => backup::VAR_COURSEID]);
         }
         $lessonattempt->annotate_ids('user', 'userid');
 
         $lessongrades = new backup_nested_element('lessongrades');
-        $lessongrade = new backup_nested_element('lessongrade', array('id'), array(
-            'lessonid', 'userid', 'grade', 'late', 'completed', 'course'));
+        $lessongrade = new backup_nested_element('lessongrade', ['id'], [
+                'lessonid', 'userid', 'grade', 'late', 'completed', 'course']);
 
         $recompletion->add_child($lessongrades);
         $lessongrades->add_child($lessongrade);
 
         if ($usercompletion) {
-            $lessongrade->set_source_table('local_recompletion_lg', array('course' => backup::VAR_COURSEID));
+            $lessongrade->set_source_table('local_recompletion_lg', ['course' => backup::VAR_COURSEID]);
         }
         $lessongrade->annotate_ids('user', 'userid');
 
         $lessontimers = new backup_nested_element('lessontimers');
-        $lessontimer = new backup_nested_element('lessontimer', array('id'), array(
-            'lessonid', 'userid', 'starttime', 'lessontime', 'completed', 'timemodifiedoffline', 'course'));
+        $lessontimer = new backup_nested_element('lessontimer', ['id'], [
+                'lessonid', 'userid', 'starttime', 'lessontime', 'completed', 'timemodifiedoffline', 'course']);
 
         $recompletion->add_child($lessontimers);
         $lessontimers->add_child($lessontimer);
 
         if ($usercompletion) {
-            $lessontimer->set_source_table('local_recompletion_lt', array('course' => backup::VAR_COURSEID));
+            $lessontimer->set_source_table('local_recompletion_lt', ['course' => backup::VAR_COURSEID]);
         }
         $lessontimer->annotate_ids('user', 'userid');
 
         $lessonbraches = new backup_nested_element('lessonbraches');
-        $lessonbranch = new backup_nested_element('lessonbranch', array('id'), array(
-            'lessonid', 'userid', 'pageid', 'retry', 'flag', 'timeseen', 'nextpageid', 'course'));
+        $lessonbranch = new backup_nested_element('lessonbranch', ['id'], [
+                'lessonid', 'userid', 'pageid', 'retry', 'flag', 'timeseen', 'nextpageid', 'course']);
 
         $recompletion->add_child($lessonbraches);
         $lessonbraches->add_child($lessonbranch);
 
         if ($usercompletion) {
-            $lessonbranch->set_source_table('local_recompletion_lb', array('course' => backup::VAR_COURSEID));
+            $lessonbranch->set_source_table('local_recompletion_lb', ['course' => backup::VAR_COURSEID]);
         }
         $lessonbranch->annotate_ids('user', 'userid');
 
         $lessonoverrides = new backup_nested_element('lessonoverrides');
-        $lessonoverride = new backup_nested_element('lessonoverride', array('id'), array(
-            'lessonid', 'groupid', 'userid', 'available', 'deadline', 'timelimit',
-            'review', 'maxattempts', 'retake', 'password', 'course'));
+        $lessonoverride = new backup_nested_element('lessonoverride', ['id'], [
+                'lessonid', 'groupid', 'userid', 'available', 'deadline', 'timelimit',
+                'review', 'maxattempts', 'retake', 'password', 'course']);
 
         $recompletion->add_child($lessonoverrides);
         $lessonoverrides->add_child($lessonoverride);
 
         if ($usercompletion) {
-            $lessonoverride->set_source_table('local_recompletion_lo', array('course' => backup::VAR_COURSEID));
+            $lessonoverride->set_source_table('local_recompletion_lo', ['course' => backup::VAR_COURSEID]);
         }
         $lessonoverride->annotate_ids('user', 'userid');
 
         // Now deal with hotpot archive tables.
         $hotpotattempts = new backup_nested_element('hotpotattempts');
-        $hotpotattempt = new backup_nested_element('hotpotattempt', array('id'), array(
-            'hotpotid', 'userid', 'starttime', 'endtime', 'score', 'penalties', 'attempt', 'timestart',
-            'timefinish', 'status', 'clickreportid', 'timemodified', 'course'));
+        $hotpotattempt = new backup_nested_element('hotpotattempt', ['id'], [
+                'hotpotid', 'userid', 'starttime', 'endtime', 'score', 'penalties', 'attempt', 'timestart',
+                'timefinish', 'status', 'clickreportid', 'timemodified', 'course']);
 
         $recompletion->add_child($hotpotattempts);
         $hotpotattempts->add_child($hotpotattempt);
 
         if ($usercompletion) {
-            $hotpotattempt->set_source_table('local_recompletion_hpa', array('course' => backup::VAR_COURSEID));
+            $hotpotattempt->set_source_table('local_recompletion_hpa', ['course' => backup::VAR_COURSEID]);
         }
         $hotpotattempt->annotate_ids('user', 'userid');
 
         // Now deal mod_certificate archive table.
         $certificates = new backup_nested_element('certificates');
-        $certificate = new backup_nested_element('certificate', array('id'), array(
-            'userid', 'certificateid', 'code', 'timecreated', 'printdate', 'course'));
+        $certificate = new backup_nested_element('certificate', ['id'], [
+                'userid', 'certificateid', 'code', 'timecreated', 'printdate', 'course']);
 
         $recompletion->add_child($certificates);
         $certificates->add_child($certificate);
 
         if ($usercompletion) {
-            $certificate->set_source_table('local_recompletion_cert', array('course' => backup::VAR_COURSEID));
+            $certificate->set_source_table('local_recompletion_cert', ['course' => backup::VAR_COURSEID]);
         }
         $certificate->annotate_ids('user', 'userid');
 

--- a/backup/moodle2/restore_local_recompletion_plugin.class.php
+++ b/backup/moodle2/restore_local_recompletion_plugin.class.php
@@ -36,35 +36,36 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
      * Returns the paths to be handled by the plugin at course level.
      */
     protected function define_course_plugin_structure() {
-        $paths = array();
+        $paths = [];
 
         $elepath = $this->get_pathfor('/');
-        $paths[] = new restore_path_element('recompletion', $elepath.'/recompletion_config');
-        $paths[] = new restore_path_element('recompletion_cc', $elepath.'/course_completion/coursecompletion');
+        $paths[] = new restore_path_element('recompletion', $elepath . '/recompletion_config');
+        $paths[] = new restore_path_element('recompletion_cc', $elepath . '/course_completion/coursecompletion');
         $paths[] = new restore_path_element('recompletion_cc_cc',
-            $elepath.'/course_completion/course_completion_crit_completions/course_completion_crit_compl');
-        $paths[] = new restore_path_element('recompletion_completion', $elepath.'/course_completion/completions/completion');
-        $paths[] = new restore_path_element('recompletion_qa', $elepath.'/quizattempts/attempt');
-        $paths[] = new restore_path_element('recompletion_qg', $elepath.'/quizgrades/grade');
-        $paths[] = new restore_path_element('recompletion_sa', $elepath.'/scormattempts/scormattempt');
-        $paths[] = new restore_path_element('recompletion_ssv', $elepath.'/scormtracks/sco_track');
-        $paths[] = new restore_path_element('recompletion_cha', $elepath.'/choiceanswers/choiceanswer');
-        $paths[] = new restore_path_element('recompletion_hvp', $elepath.'/hvpattempts/hvpattempt');
-        $paths[] = new restore_path_element('recompletion_h5p', $elepath.'/h5ps/h5p');
-        $paths[] = new restore_path_element('recompletion_h5pr', $elepath.'/h5ps/h5p/h5presults/h5presult');
-        $paths[] = new restore_path_element('recompletion_lessonattempt', $elepath.'/lessonattempts/lessonattempt');
-        $paths[] = new restore_path_element('recompletion_lessongrade', $elepath.'/lessongrades/lessongrade');
-        $paths[] = new restore_path_element('recompletion_lessontimer', $elepath.'/lessontimers/lessontimer');
-        $paths[] = new restore_path_element('recompletion_lessonbrach', $elepath.'/lessonbraches/lessonbrach');
-        $paths[] = new restore_path_element('recompletion_lessonoverride', $elepath.'/lessonoverrides/lessonoverride');
-        $paths[] = new restore_path_element('recompletion_hpa', $elepath.'/hotpotattempts/hotpotattempt');
-        $paths[] = new restore_path_element('recompletion_cert', $elepath.'/certificates/certificate');
+                $elepath . '/course_completion/course_completion_crit_completions/course_completion_crit_compl');
+        $paths[] = new restore_path_element('recompletion_completion', $elepath . '/course_completion/completions/completion');
+        $paths[] = new restore_path_element('recompletion_qa', $elepath . '/quizattempts/attempt');
+        $paths[] = new restore_path_element('recompletion_qg', $elepath . '/quizgrades/grade');
+        $paths[] = new restore_path_element('recompletion_sa', $elepath . '/scormattempts/scormattempt');
+        $paths[] = new restore_path_element('recompletion_ssv', $elepath . '/scormtracks/sco_track');
+        $paths[] = new restore_path_element('recompletion_cha', $elepath . '/choiceanswers/choiceanswer');
+        $paths[] = new restore_path_element('recompletion_hvp', $elepath . '/hvpattempts/hvpattempt');
+        $paths[] = new restore_path_element('recompletion_h5p', $elepath . '/h5ps/h5p');
+        $paths[] = new restore_path_element('recompletion_h5pr', $elepath . '/h5ps/h5p/h5presults/h5presult');
+        $paths[] = new restore_path_element('recompletion_lessonattempt', $elepath . '/lessonattempts/lessonattempt');
+        $paths[] = new restore_path_element('recompletion_lessongrade', $elepath . '/lessongrades/lessongrade');
+        $paths[] = new restore_path_element('recompletion_lessontimer', $elepath . '/lessontimers/lessontimer');
+        $paths[] = new restore_path_element('recompletion_lessonbrach', $elepath . '/lessonbraches/lessonbrach');
+        $paths[] = new restore_path_element('recompletion_lessonoverride', $elepath . '/lessonoverrides/lessonoverride');
+        $paths[] = new restore_path_element('recompletion_hpa', $elepath . '/hotpotattempts/hotpotattempt');
+        $paths[] = new restore_path_element('recompletion_cert', $elepath . '/certificates/certificate');
 
         return $paths;
     }
 
     /**
      * Process local_recompletion table.
+     *
      * @param stdClass $data
      */
     public function process_recompletion($data) {
@@ -88,6 +89,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
 
     /**
      * Process local_recompletion_cc table.
+     *
      * @param stdClass $data
      */
     public function process_recompletion_cc($data) {
@@ -102,6 +104,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
 
     /**
      * Process course_completion_crit_compl table.
+     *
      * @param stdClass $data
      */
     public function process_recompletion_cc_cc($data) {
@@ -117,6 +120,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
 
     /**
      * Process local_recompletion_cmc table.
+     *
      * @param stdClass $data
      */
     public function process_recompletion_completion($data) {
@@ -131,6 +135,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
 
     /**
      * Process local_recompletion_qa table.
+     *
      * @param stdClass $data
      */
     public function process_recompletion_qa($data) {
@@ -145,6 +150,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
 
     /**
      * Process local_recompletion_qg table.
+     *
      * @param stdClass $data
      */
     public function process_recompletion_qg($data) {
@@ -159,6 +165,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
 
     /**
      * Process local_recompletion_sa table.
+     *
      * @param stdClass $data
      */
     public function process_recompletion_sa($data) {
@@ -173,6 +180,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
 
     /**
      * Process local_recompletion_sst table.
+     *
      * @param stdClass $data
      */
     public function process_recompletion_ssv($data) {
@@ -186,6 +194,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
 
     /**
      * Process local_recompletion_cha table.
+     *
      * @param stdClass $data
      */
     public function process_recompletion_cha($data) {
@@ -200,6 +209,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
 
     /**
      * Process local_recompletion_hvp table.
+     *
      * @param stdClass $data
      */
     public function process_recompletion_hvp($data) {
@@ -214,6 +224,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
 
     /**
      * Process local_recompletion_h5p table.
+     *
      * @param stdClass $data
      */
     public function process_recompletion_h5p($data) {
@@ -230,6 +241,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
 
     /**
      * Process local_recompletion_h5pr table.
+     *
      * @param stdClass $data
      */
     public function process_recompletion_h5pr($data) {
@@ -243,6 +255,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
 
     /**
      * Process local_recompletion_lessonattempt.
+     *
      * @param stdClass $data
      */
     public function process_recompletion_lessonattempt($data) {
@@ -259,6 +272,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
 
     /**
      * Process local_recompletion_lessongrade.
+     *
      * @param stdClass $data
      */
     public function process_recompletion_lessongrade($data) {
@@ -275,6 +289,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
 
     /**
      * Process local_recompletion_lessontimer.
+     *
      * @param stdClass $data
      */
     public function process_recompletion_lessontimer($data) {
@@ -291,6 +306,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
 
     /**
      * Process local_recompletion_lessonbrach.
+     *
      * @param stdClass $data
      */
     public function process_recompletion_lessonbrach($data) {
@@ -307,6 +323,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
 
     /**
      * Process local_recompletion_lessonoverride.
+     *
      * @param stdClass $data
      */
     public function process_recompletion_lessonoverride($data) {
@@ -323,6 +340,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
 
     /**
      * Process local_recompletion_hpa table.
+     *
      * @param stdClass $data
      */
     public function process_recompletion_hpa($data) {
@@ -337,6 +355,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
 
     /**
      * Process local_recompletion_cert table.
+     *
      * @param stdClass $data
      */
     public function process_recompletion_cert($data) {
@@ -355,7 +374,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
     protected function after_restore_course() {
         global $DB;
         // Fix local_recompletion_cmc records.
-        $rcm = $DB->get_recordset('local_recompletion_cmc', array('course' => $this->task->get_courseid()));
+        $rcm = $DB->get_recordset('local_recompletion_cmc', ['course' => $this->task->get_courseid()]);
         foreach ($rcm as $rc) {
             $rc->coursemoduleid = $this->get_mappingid('course_module', $rc->coursemoduleid);
             $DB->update_record('local_recompletion_cmc', $rc);
@@ -363,7 +382,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
         $rcm->close();
 
         // Fix SCORM tracks.
-        $rcm = $DB->get_recordset('local_recompletion_sa', array('courseid' => $this->task->get_courseid()));
+        $rcm = $DB->get_recordset('local_recompletion_sa', ['courseid' => $this->task->get_courseid()]);
         foreach ($rcm as $rc) {
             $rc->scormid = $this->get_mappingid('scorm', $rc->scormid);
             $DB->update_record('local_recompletion_sa', $rc);
@@ -371,14 +390,14 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
         $rcm->close();
 
         // Fix Quiz.
-        $rcm = $DB->get_recordset('local_recompletion_qg', array('course' => $this->task->get_courseid()));
+        $rcm = $DB->get_recordset('local_recompletion_qg', ['course' => $this->task->get_courseid()]);
         foreach ($rcm as $rc) {
             $rc->quiz = $this->get_mappingid('quiz', $rc->quiz);
             $DB->update_record('local_recompletion_qg', $rc);
         }
         $rcm->close();
 
-        $rcm = $DB->get_recordset('local_recompletion_qa', array('course' => $this->task->get_courseid()));
+        $rcm = $DB->get_recordset('local_recompletion_qa', ['course' => $this->task->get_courseid()]);
         foreach ($rcm as $rc) {
             $rc->quiz = $this->get_mappingid('quiz', $rc->quiz);
             $rc->uniqueid = $this->get_mappingid('question_usage', $rc->uniqueid);
@@ -387,7 +406,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
         $rcm->close();
 
         // Fix Choice answers.
-        $rcm = $DB->get_recordset('local_recompletion_cha', array('course' => $this->task->get_courseid()));
+        $rcm = $DB->get_recordset('local_recompletion_cha', ['course' => $this->task->get_courseid()]);
         foreach ($rcm as $rc) {
             $rc->choiceid = $this->get_mappingid('choice', $rc->choiceid);
             $DB->update_record('local_recompletion_cha', $rc);
@@ -395,7 +414,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
         $rcm->close();
 
         // Fix hvp attempts.
-        $rcm = $DB->get_recordset('local_recompletion_hvp', array('course' => $this->task->get_courseid()));
+        $rcm = $DB->get_recordset('local_recompletion_hvp', ['course' => $this->task->get_courseid()]);
         foreach ($rcm as $rc) {
             $rc->hvp_id = $this->get_mappingid('hvp', $rc->hvp_id);
             $DB->update_record('local_recompletion_hvp', $rc);
@@ -403,7 +422,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
         $rcm->close();
 
         // Fix h5p attempts.
-        $rcm = $DB->get_recordset('local_recompletion_h5p', array('course' => $this->task->get_courseid()));
+        $rcm = $DB->get_recordset('local_recompletion_h5p', ['course' => $this->task->get_courseid()]);
         foreach ($rcm as $rc) {
             $rc->h5pactivityid = $this->get_mappingid('h5pactivity', $rc->h5pactivityid);
             $rc->originalattemptid = 0; // Don't restore orginal attempt id.
@@ -413,11 +432,11 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
         $rcm->close();
 
         // Fix lesson tables.
-        $tables = array('local_recompletion_la', 'local_recompletion_lg', 'local_recompletion_lt',
-            'local_recompletion_lb', 'local_recompletion_lo');
+        $tables = ['local_recompletion_la', 'local_recompletion_lg', 'local_recompletion_lt',
+                'local_recompletion_lb', 'local_recompletion_lo'];
 
         foreach ($tables as $table) {
-            $rcm = $DB->get_recordset($table, array('course' => $this->task->get_courseid()));
+            $rcm = $DB->get_recordset($table, ['course' => $this->task->get_courseid()]);
             foreach ($rcm as $rc) {
                 $rc->lessonid = $this->get_mappingid('lesson', $rc->lessonid);
                 $DB->update_record($table, $rc);
@@ -426,7 +445,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
         }
 
         // Fix hotpot attempts.
-        $rcm = $DB->get_recordset('local_recompletion_hpa', array('course' => $this->task->get_courseid()));
+        $rcm = $DB->get_recordset('local_recompletion_hpa', ['course' => $this->task->get_courseid()]);
         foreach ($rcm as $rc) {
             $rc->hotpotid = $this->get_mappingid('hotpot', $rc->hotpotid);
             $DB->update_record('local_recompletion_hpa', $rc);
@@ -434,7 +453,7 @@ class restore_local_recompletion_plugin extends restore_local_plugin {
         $rcm->close();
 
         // Fix certificates.
-        $rcm = $DB->get_recordset('local_recompletion_cert', array('course' => $this->task->get_courseid()));
+        $rcm = $DB->get_recordset('local_recompletion_cert', ['course' => $this->task->get_courseid()]);
         foreach ($rcm as $rc) {
             $rc->certificateid = $this->get_mappingid('certificate', $rc->certificateid);
             $DB->update_record('local_recompletion_cert', $rc);

--- a/bulkresetcompletion.php
+++ b/bulkresetcompletion.php
@@ -29,8 +29,8 @@ require_once($CFG->dirroot . '/user/lib.php');
 require_once($CFG->libdir . '/formslib.php');
 
 $courseid = required_param('id', PARAM_INT);
-$userid   = optional_param('user', 0, PARAM_INT);
-$users    = optional_param_array('users', [], PARAM_INT);
+$userid = optional_param('user', 0, PARAM_INT);
+$users = optional_param_array('users', [], PARAM_INT);
 
 $course = $DB->get_record('course', ['id' => $courseid], '*', MUST_EXIST);
 require_login($course);
@@ -52,7 +52,7 @@ if (empty($users) && empty($userid)) {
 
     if (empty($users)) {
         redirect($CFG->wwwroot . '/local/recompletion/participants.php?id=' . $course->id,
-            get_string('nousersselected', 'local_recompletion'));
+                get_string('nousersselected', 'local_recompletion'));
     }
 }
 
@@ -60,7 +60,7 @@ if (empty($users)) {
     $users = [$userid];
     // Get this users current completion date and use that in the form.
     $params = ['userid' => $userid, 'course' => $courseid];
-    $ccompletion = new \completion_completion($params);
+    $ccompletion = new completion_completion($params);
     if ($ccompletion->is_complete()) {
         $date = $ccompletion->timecompleted;
     }
@@ -72,9 +72,9 @@ if (empty($date)) {
 }
 
 $form = new local_recompletion_coursecompletion_form('editcompletion.php', [
-    'course' => $courseid,
-    'users' => $users,
-    'date' => $date,
+        'course' => $courseid,
+        'users' => $users,
+        'date' => $date,
 ]);
 
 if ($form->is_cancelled()) {
@@ -84,7 +84,7 @@ if ($form->is_cancelled()) {
         // Update course completion.
         local_recompletion_update_course_completion($courseid, $users, $data->newcompletion);
         redirect($CFG->wwwroot . '/local/recompletion/participants.php?id=' . $course->id,
-            get_string('completionupdated', 'local_recompletion'));
+                get_string('completionupdated', 'local_recompletion'));
     }
 }
 

--- a/classes/admin_setting_configstrtotime.php
+++ b/classes/admin_setting_configstrtotime.php
@@ -16,9 +16,14 @@
 
 namespace local_recompletion;
 
+use admin_setting;
+use html_writer;
+use MoodleQuickForm;
+use function format_admin_setting;
+
 defined('MOODLE_INTERNAL') || die;
 
-require_once($CFG->dirroot.'/lib/adminlib.php');
+require_once($CFG->dirroot . '/lib/adminlib.php');
 
 /**
  * A strtotime based admin setting config
@@ -28,7 +33,7 @@ require_once($CFG->dirroot.'/lib/adminlib.php');
  * @copyright  Catalyst IT, 2023
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class admin_setting_configstrtotime extends \admin_setting {
+class admin_setting_configstrtotime extends admin_setting {
 
     /**
      * Return the structure configuration for this setting if it has been set.
@@ -53,7 +58,7 @@ class admin_setting_configstrtotime extends \admin_setting {
     public function validate($data) {
         $value = local_recompletion_calculate_schedule_time($data);
         if ($value === 0) {
-            return  get_string('invalidscheduledate', 'local_recompletion');
+            return get_string('invalidscheduledate', 'local_recompletion');
         }
 
         return true;
@@ -81,10 +86,10 @@ class admin_setting_configstrtotime extends \admin_setting {
      * @param string $query
      * @return string
      */
-    public function output_html($data, $query='') {
+    public function output_html($data, $query = '') {
         $prefix = $this->get_full_name();
         // Use MoodleQuickForm to build the form.
-        $mform = new \MoodleQuickForm('unused', 'unused', 'unused');
+        $mform = new MoodleQuickForm('unused', 'unused', 'unused');
 
         // Handle display of errors.
         $errors = self::validate($data ?: '');
@@ -104,20 +109,20 @@ class admin_setting_configstrtotime extends \admin_setting {
             $calculated = local_recompletion_calculate_schedule_time($data);
             $formatted = userdate($calculated, get_string('strftimedatetime', 'langconfig'));
             $mform->addElement('static', 'calculatedtime',
-                               get_string('recompletioncalculateddate', 'local_recompletion', $formatted));
+                    get_string('recompletioncalculateddate', 'local_recompletion', $formatted));
         }
 
         $html = $mform->toHtml();
 
-        return \format_admin_setting(
-            $this,
-            $this->visiblename,
-            \html_writer::div($html, 'w-100'),
-            $this->description,
-            true,
-            '',
-            '',
-            $query,
+        return format_admin_setting(
+                $this,
+                $this->visiblename,
+                html_writer::div($html, 'w-100'),
+                $this->description,
+                true,
+                '',
+                '',
+                $query,
         );
     }
 }

--- a/classes/event/completion_reset.php
+++ b/classes/event/completion_reset.php
@@ -25,6 +25,8 @@
 
 namespace local_recompletion\event;
 
+use core\event\base;
+
 /**
  * completion_reset event class.
  *
@@ -36,7 +38,7 @@ namespace local_recompletion\event;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  *
  */
-class completion_reset extends \core\event\base {
+class completion_reset extends base {
     /**
      * Init method.
      *

--- a/classes/local/restrictions/base.php
+++ b/classes/local/restrictions/base.php
@@ -64,6 +64,7 @@ abstract class base {
 
     /**
      * Get restriction reason.
+     *
      * @return string
      */
     public static function get_restriction_reason(): string {

--- a/classes/local/restrictions/enrol.php
+++ b/classes/local/restrictions/enrol.php
@@ -16,6 +16,7 @@
 
 namespace local_recompletion\local\restrictions;
 
+use admin_setting_configmulticheckbox;
 use admin_settingpage;
 use core_component;
 use MoodleQuickForm;
@@ -38,22 +39,22 @@ class enrol extends base {
     public static function editingform(MoodleQuickForm $mform): void {
         $config = get_config('local_recompletion');
         $options = [
-            'multiple' => true,
-            'noselectionstring' => get_string('all'),
+                'multiple' => true,
+                'noselectionstring' => get_string('all'),
         ];
 
         $plugins = array_keys(core_component::get_plugin_list('enrol'));
         $enrolplugins = array_map(
-            fn (string $plugin): string => get_string('pluginname', 'enrol_' . $plugin),
-            array_combine($plugins, $plugins)
+                fn(string $plugin): string => get_string('pluginname', 'enrol_' . $plugin),
+                array_combine($plugins, $plugins)
         );
 
         $mform->addElement(
-            'autocomplete',
-            'restrictenrol',
-            get_string('restrictenrol', 'local_recompletion'),
-            $enrolplugins,
-            $options
+                'autocomplete',
+                'restrictenrol',
+                get_string('restrictenrol', 'local_recompletion'),
+                $enrolplugins,
+                $options
         );
 
         $mform->setDefault('restrictenrol', $config->restrictenrol);
@@ -62,6 +63,7 @@ class enrol extends base {
 
     /**
      * Set form data after submitting.
+     *
      * @param stdClass $data
      */
     public static function set_form_data(stdClass $data): void {
@@ -78,16 +80,16 @@ class enrol extends base {
     public static function settings(admin_settingpage $settings): void {
         $enrolplugins = array_keys(core_component::get_plugin_list('enrol'));
         $options = array_map(
-            fn (string $plugin): string => get_string('pluginname', 'enrol_' . $plugin),
-            array_combine($enrolplugins, $enrolplugins)
+                fn(string $plugin): string => get_string('pluginname', 'enrol_' . $plugin),
+                array_combine($enrolplugins, $enrolplugins)
         );
 
-        $settings->add(new \admin_setting_configmulticheckbox(
-            'local_recompletion/restrictenrol',
-            get_string('restrictenrol', 'local_recompletion'),
-            get_string('restrictenrol_help', 'local_recompletion'),
-            [],
-            $options
+        $settings->add(new admin_setting_configmulticheckbox(
+                'local_recompletion/restrictenrol',
+                get_string('restrictenrol', 'local_recompletion'),
+                get_string('restrictenrol_help', 'local_recompletion'),
+                [],
+                $options
         ));
     }
 
@@ -109,7 +111,7 @@ class enrol extends base {
         $allowedenrols = explode(',', $config->restrictenrol);
         $courseinstances = enrol_get_instances($course->id, false);
 
-        $courseallowedinstances = array_filter($courseinstances, function ($courseinstance) use ($allowedenrols){
+        $courseallowedinstances = array_filter($courseinstances, function($courseinstance) use ($allowedenrols) {
             return in_array($courseinstance->enrol, $allowedenrols);
         });
 
@@ -119,7 +121,7 @@ class enrol extends base {
         }
 
         // Check if a user is enrolled using one of the allowed instances.
-        list($sql, $params) = $DB->get_in_or_equal(array_keys($courseallowedinstances), SQL_PARAMS_NAMED);
+        [$sql, $params] = $DB->get_in_or_equal(array_keys($courseallowedinstances), SQL_PARAMS_NAMED);
         $params['userid'] = $userid;
         $userenrolments = $DB->get_records_select('user_enrolments', "enrolid $sql AND userid = :userid", $params);
 
@@ -128,6 +130,7 @@ class enrol extends base {
 
     /**
      * Get restriction reason.
+     *
      * @return string
      */
     public static function get_restriction_reason(): string {

--- a/classes/observer.php
+++ b/classes/observer.php
@@ -16,9 +16,16 @@
 
 namespace local_recompletion;
 
+use completion_completion;
+use core\event\course_created;
+use core\event\user_enrolment_deleted;
+use Exception;
+use local_recompletion\task\check_recompletion;
+use mod_assign\event\submission_graded;
+
 defined('MOODLE_INTERNAL') || die;
 
-require_once($CFG->dirroot.'/local/recompletion/locallib.php');
+require_once($CFG->dirroot . '/local/recompletion/locallib.php');
 
 /**
  * Class local_recompletion_observer
@@ -30,20 +37,21 @@ require_once($CFG->dirroot.'/local/recompletion/locallib.php');
 class observer {
     /**
      * Observer function to handle the assessable_uploaded event in mod_assign.
-     * @param \mod_assign\event\submission_graded $event
+     *
+     * @param submission_graded $event
      */
-    public static function submission_graded(\mod_assign\event\submission_graded $event) {
+    public static function submission_graded(submission_graded $event) {
         global $DB;
         $assign = $event->get_assign();
         $course = $assign->get_course();
         // Check if recompletion enabled.
         $config = local_recompletion_get_config($course);
         if (!empty($config->recompletiontype) && !empty($config->assignevent)) {
-            $params = array(
-                'userid'    => $event->relateduserid,
-                'course'    => $course->id
-            );
-            $ccompletion = new \completion_completion($params);
+            $params = [
+                    'userid' => $event->relateduserid,
+                    'course' => $course->id,
+            ];
+            $ccompletion = new completion_completion($params);
             // Only update course completion date if already flagged complete.
             if ($ccompletion->is_complete()) {
                 // If we already have a completion date, clear it first so that mark_complete works.
@@ -55,9 +63,10 @@ class observer {
 
     /**
      * Observer function to handle user un-enrolment.
-     * @param \core\event\user_enrolment_deleted $event
+     *
+     * @param user_enrolment_deleted $event
      */
-    public static function user_enrolment_deleted(\core\event\user_enrolment_deleted $event) {
+    public static function user_enrolment_deleted(user_enrolment_deleted $event) {
         global $DB;
 
         $userid = $event->relateduserid;
@@ -66,25 +75,26 @@ class observer {
         $config = local_recompletion_get_config($course);
         if (!empty($config->recompletiontype) && !empty($config->recompletionunenrolenable)) {
             try {
-                $reset = new \local_recompletion\task\check_recompletion();
+                $reset = new check_recompletion();
                 $errors = $reset->reset_user($userid, $course);
-            } catch (\Exception $exception) {
+            } catch (Exception $exception) {
                 $errors = [$exception->getMessage()];
             }
 
             if (!empty($errors)) {
                 // TODO: implement a new completion_reset_failed event.
                 debugging('Completion reset failed for user ' . $userid .
-                    ' in course ' . $course->id . ' Errors: ' . implode(',', $errors), DEBUG_DEVELOPER);
+                        ' in course ' . $course->id . ' Errors: ' . implode(',', $errors), DEBUG_DEVELOPER);
             }
         }
     }
 
     /**
      * Observer function to handle saving default settings on course creation.
-     * @param \core\event\course_created $event
+     *
+     * @param course_created $event
      */
-    public static function course_created(\core\event\course_created $event) {
+    public static function course_created(course_created $event) {
         global $DB;
 
         $defaultsettings = get_config('local_recompletion');
@@ -96,21 +106,21 @@ class observer {
                 }
                 if ($key === 'recompletionemailbody' && !empty($value)) {
                     $DB->insert_record('local_recompletion_config', [
-                        'course' => $event->courseid,
-                        'name' => 'recompletionemailbody_format',
-                        'value' => FORMAT_HTML]);
+                            'course' => $event->courseid,
+                            'name' => 'recompletionemailbody_format',
+                            'value' => FORMAT_HTML]);
                 }
                 if ($key === 'recompletionschedule' && !empty($value)) {
                     $nextresttime = local_recompletion_calculate_schedule_time($value);
                     $DB->insert_record('local_recompletion_config', [
-                        'course' => $event->courseid,
-                        'name' => 'nextresettime',
-                        'value' => $nextresttime]);
+                            'course' => $event->courseid,
+                            'name' => 'nextresettime',
+                            'value' => $nextresttime]);
                 }
                 $setting = [
-                    'name' => $key,
-                    'value' => $value,
-                    'course' => $event->courseid
+                        'name' => $key,
+                        'value' => $value,
+                        'course' => $event->courseid,
                 ];
 
                 $DB->insert_record('local_recompletion_config', $setting);

--- a/classes/plugins/mod_assign.php
+++ b/classes/plugins/mod_assign.php
@@ -25,7 +25,15 @@
 
 namespace local_recompletion\plugins;
 
+use admin_setting_configcheckbox;
+use admin_setting_configselect;
+use assign;
+use coding_exception;
+use context_module;
+use dml_exception;
 use lang_string;
+use ReflectionMethod;
+use stdClass;
 
 /**
  * Quiz handler event.
@@ -39,20 +47,21 @@ use lang_string;
 class mod_assign {
     /**
      * Add params to form.
+     *
      * @param moodleform $mform
-     * @throws \coding_exception
-     * @throws \dml_exception
+     * @throws coding_exception
+     * @throws dml_exception
      */
     public static function editingform($mform): void {
         $config = get_config('local_recompletion');
 
-        $cba = array();
+        $cba = [];
         $cba[] = $mform->createElement('radio', 'assign', '',
-            get_string('donothing', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING);
+                get_string('donothing', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING);
         $cba[] = $mform->createElement('radio', 'assign', '',
-            get_string('extraattempt', 'local_recompletion'), LOCAL_RECOMPLETION_EXTRAATTEMPT);
+                get_string('extraattempt', 'local_recompletion'), LOCAL_RECOMPLETION_EXTRAATTEMPT);
 
-        $mform->addGroup($cba, 'assign', get_string('assignattempts', 'local_recompletion'), array(' '), false);
+        $mform->addGroup($cba, 'assign', get_string('assignattempts', 'local_recompletion'), [' '], false);
         $mform->addHelpButton('assign', 'assignattempts', 'local_recompletion');
         $mform->setDefault('assign', $config->assign);
 
@@ -69,23 +78,24 @@ class mod_assign {
      * @param admin_settingpage $settings
      */
     public static function settings($settings) {
-        $choices = array(LOCAL_RECOMPLETION_NOTHING => new lang_string('donothing', 'local_recompletion'),
-            LOCAL_RECOMPLETION_EXTRAATTEMPT => new lang_string('extraattempt', 'local_recompletion'));
+        $choices = [LOCAL_RECOMPLETION_NOTHING => new lang_string('donothing', 'local_recompletion'),
+                LOCAL_RECOMPLETION_EXTRAATTEMPT => new lang_string('extraattempt', 'local_recompletion')];
 
-        $settings->add(new \admin_setting_configselect('local_recompletion/assign',
-            new lang_string('assignattempts', 'local_recompletion'),
-            new lang_string('assignattempts_help', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING, $choices));
+        $settings->add(new admin_setting_configselect('local_recompletion/assign',
+                new lang_string('assignattempts', 'local_recompletion'),
+                new lang_string('assignattempts_help', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING, $choices));
 
-        $settings->add(new \admin_setting_configcheckbox('local_recompletion/assignevent',
-            new lang_string('assignevent', 'local_recompletion'),
-            '', 0));
+        $settings->add(new admin_setting_configcheckbox('local_recompletion/assignevent',
+                new lang_string('assignevent', 'local_recompletion'),
+                '', 0));
     }
 
     /**
      * Reset assign records.
-     * @param \int $userid - record with user information for recompletion
-     * @param \stdClass $course - course record.
-     * @param \stdClass $config - recompletion config.
+     *
+     * @param int $userid - record with user information for recompletion
+     * @param stdClass $course - course record.
+     * @param stdClass $config - recompletion config.
      */
     public static function reset($userid, $course, $config) {
         global $DB;
@@ -96,17 +106,17 @@ class mod_assign {
                       FROM {assign} a
                       JOIN {assign_submission} s ON a.id = s.assignment
                      WHERE a.course = ? AND s.userid = ?";
-            $assigns = $DB->get_recordset_sql($sql, array($course->id, $userid));
+            $assigns = $DB->get_recordset_sql($sql, [$course->id, $userid]);
             $nopermissions = false;
             foreach ($assigns as $assign) {
                 $cm = get_coursemodule_from_instance('assign', $assign->id);
-                $context = \context_module::instance($cm->id);
+                $context = context_module::instance($cm->id);
                 if (has_capability('mod/assign:grade', $context)) {
                     // Assign add_attempt() is protected and requires sesskey, use reflection so we don't have to write our own.
                     $_POST['sesskey'] = sesskey();
-                    $r = new \ReflectionMethod('assign', 'add_attempt');
+                    $r = new ReflectionMethod('assign', 'add_attempt');
                     $r->setAccessible(true);
-                    $r->invoke(new \assign($context, $cm, $course), $userid);
+                    $r->invoke(new assign($context, $cm, $course), $userid);
                 } else {
                     $nopermissions = true;
                 }

--- a/classes/plugins/mod_certificate.php
+++ b/classes/plugins/mod_certificate.php
@@ -26,7 +26,7 @@ use MoodleQuickForm;
 
 defined('MOODLE_INTERNAL') || die;
 
-require_once($CFG->dirroot.'/local/recompletion/locallib.php');
+require_once($CFG->dirroot . '/local/recompletion/locallib.php');
 
 /**
  * Certificate handler event.
@@ -91,8 +91,8 @@ class mod_certificate {
         }
 
         $choices = [
-            LOCAL_RECOMPLETION_NOTHING => get_string('donothing', 'local_recompletion'),
-            LOCAL_RECOMPLETION_DELETE => get_string('customcertresetcertificates', 'local_recompletion')
+                LOCAL_RECOMPLETION_NOTHING => get_string('donothing', 'local_recompletion'),
+                LOCAL_RECOMPLETION_DELETE => get_string('customcertresetcertificates', 'local_recompletion'),
         ];
 
         $settings->add(new admin_setting_configselect('local_recompletion/certificate',
@@ -124,8 +124,8 @@ class mod_certificate {
 
         if ($config->certificate == LOCAL_RECOMPLETION_DELETE) {
             $params = [
-                'userid' => $userid,
-                'courseid' => $course->id,
+                    'userid' => $userid,
+                    'courseid' => $course->id,
             ];
 
             if ($config->archivecertificate) {
@@ -142,10 +142,10 @@ class mod_certificate {
                     // Depending on activity settings actual date printed on a certificate can be different
                     // to a date of issue. Let's try to build printed date and archive it as well for future verification.
                     $issuedcerts[$ic]->printdate = self::certificate_get_date(
-                        $issuedcerts[$ic]->timecreated,
-                        $issuedcerts[$ic]->printdate,
-                        (object) ['id' => $course->id],
-                        $userid
+                            $issuedcerts[$ic]->timecreated,
+                            $issuedcerts[$ic]->printdate,
+                            (object) ['id' => $course->id],
+                            $userid
                     );
                 }
 
@@ -161,6 +161,7 @@ class mod_certificate {
 
     /**
      * Helper function to check if it's installed.
+     *
      * @return bool
      */
     public static function installed(): bool {

--- a/classes/plugins/mod_choice.php
+++ b/classes/plugins/mod_choice.php
@@ -25,7 +25,12 @@
 
 namespace local_recompletion\plugins;
 
+use admin_setting_configcheckbox;
+use admin_setting_configselect;
+use coding_exception;
+use dml_exception;
 use lang_string;
+use stdClass;
 
 /**
  * Choice handler event.
@@ -39,25 +44,26 @@ use lang_string;
 class mod_choice {
     /**
      * Add params to form.
+     *
      * @param moodleform $mform
-     * @throws \coding_exception
-     * @throws \dml_exception
+     * @throws coding_exception
+     * @throws dml_exception
      */
-    public static function editingform($mform) : void {
+    public static function editingform($mform): void {
         $config = get_config('local_recompletion');
 
-        $cba = array();
+        $cba = [];
         $cba[] = $mform->createElement('radio', 'choice', '',
-            get_string('donothing', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING);
+                get_string('donothing', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING);
         $cba[] = $mform->createElement('radio', 'choice', '',
-            get_string('delete', 'local_recompletion'), LOCAL_RECOMPLETION_DELETE);
+                get_string('delete', 'local_recompletion'), LOCAL_RECOMPLETION_DELETE);
 
-        $mform->addGroup($cba, 'choice', get_string('choiceattempts', 'local_recompletion'), array(' '), false);
+        $mform->addGroup($cba, 'choice', get_string('choiceattempts', 'local_recompletion'), [' '], false);
         $mform->addHelpButton('choice', 'choiceattempts', 'local_recompletion');
         $mform->setDefault('choice', $config->choice);
 
         $mform->addElement('checkbox', 'archivechoice',
-            get_string('archive', 'local_recompletion'));
+                get_string('archive', 'local_recompletion'));
         $mform->setDefault('archivechoice', $config->archivechoice);
 
         $mform->disabledIf('archivechoice', 'enable', 'notchecked');
@@ -72,22 +78,23 @@ class mod_choice {
      */
     public static function settings($settings) {
 
-        $choices = array(LOCAL_RECOMPLETION_NOTHING => new lang_string('donothing', 'local_recompletion'),
-                         LOCAL_RECOMPLETION_DELETE => new lang_string('delete', 'local_recompletion'));
+        $choices = [LOCAL_RECOMPLETION_NOTHING => new lang_string('donothing', 'local_recompletion'),
+                LOCAL_RECOMPLETION_DELETE => new lang_string('delete', 'local_recompletion')];
 
-        $settings->add(new \admin_setting_configselect('local_recompletion/choice',
-            new lang_string('choiceattempts', 'local_recompletion'),
-            new lang_string('choiceattempts_help', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING, $choices));
+        $settings->add(new admin_setting_configselect('local_recompletion/choice',
+                new lang_string('choiceattempts', 'local_recompletion'),
+                new lang_string('choiceattempts_help', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING, $choices));
 
-        $settings->add(new \admin_setting_configcheckbox('local_recompletion/archivechoice',
-            new lang_string('archivechoice', 'local_recompletion'), '', 1));
+        $settings->add(new admin_setting_configcheckbox('local_recompletion/archivechoice',
+                new lang_string('archivechoice', 'local_recompletion'), '', 1));
     }
 
     /**
      * Reset and archive choice records.
-     * @param \stdclass $userid - user id
-     * @param \stdClass $course - course record.
-     * @param \stdClass $config - recompletion config.
+     *
+     * @param stdclass $userid - user id
+     * @param stdClass $course - course record.
+     * @param stdClass $config - recompletion config.
      */
     public static function reset($userid, $course, $config) {
         global $DB;
@@ -95,7 +102,7 @@ class mod_choice {
         if (empty($config->choice)) {
             return;
         } else if ($config->choice == LOCAL_RECOMPLETION_DELETE) {
-            $params = array('userid' => $userid, 'course' => $course->id);
+            $params = ['userid' => $userid, 'course' => $course->id];
             $selectsql = 'userid = ? AND choiceid IN (SELECT id FROM {choice} WHERE course = ?)';
             if ($config->archivechoice) {
                 $choiceanswers = $DB->get_records_select('choice_answers', $selectsql, $params);

--- a/classes/plugins/mod_coursecertificate.php
+++ b/classes/plugins/mod_coursecertificate.php
@@ -23,10 +23,11 @@ use admin_setting_configcheckbox;
 use admin_settingpage;
 use core\output\notification;
 use MoodleQuickForm;
+use tool_certificate\template;
 
 defined('MOODLE_INTERNAL') || die;
 
-require_once($CFG->dirroot.'/local/recompletion/locallib.php');
+require_once($CFG->dirroot . '/local/recompletion/locallib.php');
 
 /**
  * Course certificate handler event.
@@ -91,8 +92,8 @@ class mod_coursecertificate {
         }
 
         $choices = [
-            LOCAL_RECOMPLETION_NOTHING => get_string('donothing', 'local_recompletion'),
-                LOCAL_RECOMPLETION_DELETE => get_string('customcertresetcertificates', 'local_recompletion')
+                LOCAL_RECOMPLETION_NOTHING => get_string('donothing', 'local_recompletion'),
+                LOCAL_RECOMPLETION_DELETE => get_string('customcertresetcertificates', 'local_recompletion'),
         ];
 
         $settings->add(new admin_setting_configselect('local_recompletion/coursecertificate',
@@ -124,27 +125,27 @@ class mod_coursecertificate {
 
         if ($config->coursecertificate == LOCAL_RECOMPLETION_DELETE) {
             $params = [
-                'courseid' => $course->id,
-                'component' => 'mod_coursecertificate',
-                'userid' => $userid,
+                    'courseid' => $course->id,
+                    'component' => 'mod_coursecertificate',
+                    'userid' => $userid,
             ];
 
             if ($config->archivecoursecertificate) {
                 // Archive all user's certificate within a given course.
                 $DB->execute(
-                    "UPDATE {tool_certificate_issues}
+                        "UPDATE {tool_certificate_issues}
                         SET archived = 1
                       WHERE courseid = :courseid
                             AND component = :component
                             AND userid = :userid
                             AND archived = 0",
-                    $params
+                        $params
                 );
             } else {
                 // Revoke all user's certificate within a given course.
                 $records = $DB->get_records('tool_certificate_issues', $params);
                 foreach ($records as $record) {
-                    \tool_certificate\template::instance($record->templateid)->revoke_issue($record->id);
+                    template::instance($record->templateid)->revoke_issue($record->id);
                 }
             }
         }
@@ -152,6 +153,7 @@ class mod_coursecertificate {
 
     /**
      * Helper function to check if it's installed.
+     *
      * @return bool
      */
     public static function installed(): bool {

--- a/classes/plugins/mod_customcert.php
+++ b/classes/plugins/mod_customcert.php
@@ -25,7 +25,13 @@
 
 namespace local_recompletion\plugins;
 
+use admin_setting_configcheckbox;
+use admin_setting_configselect;
+use coding_exception;
+use core\output\notification;
+use dml_exception;
 use lang_string;
+use stdClass;
 
 /**
  * Custom certificate handler event.
@@ -42,8 +48,8 @@ class mod_customcert {
      *
      * @param moodleform $mform
      *
-     * @throws \coding_exception
-     * @throws \dml_exception
+     * @throws coding_exception
+     * @throws dml_exception
      */
     public static function editingform($mform): void {
         global $OUTPUT;
@@ -53,13 +59,13 @@ class mod_customcert {
         }
         $config = get_config('local_recompletion');
 
-        $cba = array();
+        $cba = [];
         $cba[] = $mform->createElement('radio', 'customcert', '',
                 get_string('donothing', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING);
         $cba[] = $mform->createElement('radio', 'customcert', '',
                 get_string('customcertresetcertificates', 'local_recompletion'), LOCAL_RECOMPLETION_DELETE);
 
-        $mform->addGroup($cba, 'customcert', get_string('customcertcertificates', 'local_recompletion'), array(' '), false);
+        $mform->addGroup($cba, 'customcert', get_string('customcertcertificates', 'local_recompletion'), [' '], false);
         $mform->addHelpButton('customcert', 'customcertcertificates', 'local_recompletion');
         $mform->setDefault('customcert', $config->customcert);
 
@@ -68,9 +74,9 @@ class mod_customcert {
         $mform->setDefault('archivecustomcert', $config->archivecustomcert);
 
         $verifywarngroup = []; // Use a workaround to hide a static mform element based on MDL-66251.
-        $verifywarn = new \core\output\notification(
+        $verifywarn = new notification(
                 get_string('customcertresetcertificatesverifywarn', 'local_recompletion'),
-                \core\output\notification::NOTIFY_WARNING);
+                notification::NOTIFY_WARNING);
         $verifywarn->set_show_closebutton(false);
         $verifywarngroup[] =
                 $mform->createElement('static', 'customcertresetcertificatesverifywarn', '', $OUTPUT->render($verifywarn));
@@ -91,14 +97,14 @@ class mod_customcert {
         if (!self::installed()) {
             return;
         }
-        $choices = array(LOCAL_RECOMPLETION_NOTHING => get_string('donothing', 'local_recompletion'),
-                LOCAL_RECOMPLETION_DELETE => get_string('customcertresetcertificates', 'local_recompletion'));
+        $choices = [LOCAL_RECOMPLETION_NOTHING => get_string('donothing', 'local_recompletion'),
+                LOCAL_RECOMPLETION_DELETE => get_string('customcertresetcertificates', 'local_recompletion')];
 
-        $settings->add(new \admin_setting_configselect('local_recompletion/customcert',
+        $settings->add(new admin_setting_configselect('local_recompletion/customcert',
                 new lang_string('customcertcertificates', 'local_recompletion'),
                 new lang_string('customcertcertificates_help', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING, $choices));
 
-        $settings->add(new \admin_setting_configcheckbox('local_recompletion/archivecustomcert',
+        $settings->add(new admin_setting_configcheckbox('local_recompletion/archivecustomcert',
                 new lang_string('archivecustomcertcertificates', 'local_recompletion'),
                 new lang_string('archivecustomcertcertificates_help', 'local_recompletion'), 1));
     }
@@ -106,9 +112,9 @@ class mod_customcert {
     /**
      * Reset custom certificate records.
      *
-     * @param \stdclass $userid - user id
-     * @param \stdClass $course - course record.
-     * @param \stdClass $config - recompletion config.
+     * @param stdclass $userid - user id
+     * @param stdClass $course - course record.
+     * @param stdClass $config - recompletion config.
      */
     public static function reset($userid, $course, $config) {
         global $DB;
@@ -120,7 +126,7 @@ class mod_customcert {
             return;
         } else if ($config->customcert == LOCAL_RECOMPLETION_DELETE) {
             // Prepare SQL Query.
-            $params = array('userid' => $userid, 'course' => $course->id);
+            $params = ['userid' => $userid, 'course' => $course->id];
             $selectsql = 'userid = ? AND customcertid IN (SELECT id FROM {customcert} WHERE course = ?)';
 
             // If archiving is activated.
@@ -141,11 +147,12 @@ class mod_customcert {
 
     /**
      * Helper function to check if custom certificate is installed.
+     *
      * @return bool
      */
     public static function installed() {
         global $CFG;
-        if (!file_exists($CFG->dirroot.'/mod/customcert/version.php')) {
+        if (!file_exists($CFG->dirroot . '/mod/customcert/version.php')) {
             return false;
         }
         return true;

--- a/classes/plugins/mod_h5pactivity.php
+++ b/classes/plugins/mod_h5pactivity.php
@@ -25,7 +25,7 @@ use MoodleQuickForm;
 
 defined('MOODLE_INTERNAL') || die;
 
-require_once($CFG->dirroot.'/local/recompletion/locallib.php');
+require_once($CFG->dirroot . '/local/recompletion/locallib.php');
 
 /**
  * H5P handler event.
@@ -69,8 +69,8 @@ class mod_h5pactivity {
      */
     public static function settings(admin_settingpage $settings): void {
         $choices = [
-            LOCAL_RECOMPLETION_NOTHING => get_string('donothing', 'local_recompletion'),
-            LOCAL_RECOMPLETION_DELETE => get_string('delete', 'local_recompletion')
+                LOCAL_RECOMPLETION_NOTHING => get_string('donothing', 'local_recompletion'),
+                LOCAL_RECOMPLETION_DELETE => get_string('delete', 'local_recompletion'),
         ];
 
         $settings->add(new admin_setting_configselect('local_recompletion/h5pactivity',
@@ -78,7 +78,7 @@ class mod_h5pactivity {
                 new lang_string('h5pattempts_help', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING, $choices));
 
         $settings->add(new admin_setting_configcheckbox('local_recompletion/archiveh5pactivity',
-            new lang_string('archiveh5p', 'local_recompletion'), '', 1));
+                new lang_string('archiveh5p', 'local_recompletion'), '', 1));
     }
 
     /**
@@ -97,8 +97,8 @@ class mod_h5pactivity {
 
         if ($config->h5pactivity == LOCAL_RECOMPLETION_DELETE) {
             $params = [
-                'userid' => $userid,
-                'course' => $course->id
+                    'userid' => $userid,
+                    'course' => $course->id,
             ];
 
             $attemptsselectsql = 'userid = :userid AND h5pactivityid IN (SELECT id FROM {h5pactivity} WHERE course = :course)';
@@ -145,7 +145,7 @@ class mod_h5pactivity {
                     // Now reset originalattemptid as we don't need it anymore.
                     // As well as to avoid issues with backup and restore when potentially originalattemptid can clash
                     // if restoring a course from another Moodle instance.
-                    list($insql, $inparams) = $DB->get_in_or_equal($attemptids, SQL_PARAMS_NAMED);
+                    [$insql, $inparams] = $DB->get_in_or_equal($attemptids, SQL_PARAMS_NAMED);
                     $sql = "UPDATE {local_recompletion_h5p} SET originalattemptid = 0 WHERE originalattemptid $insql";
                     $DB->execute($sql, $inparams);
                 }

--- a/classes/plugins/mod_hotpot.php
+++ b/classes/plugins/mod_hotpot.php
@@ -25,7 +25,7 @@ use MoodleQuickForm;
 
 defined('MOODLE_INTERNAL') || die;
 
-require_once($CFG->dirroot.'/local/recompletion/locallib.php');
+require_once($CFG->dirroot . '/local/recompletion/locallib.php');
 
 /**
  * Hotpot handler event.
@@ -77,8 +77,8 @@ class mod_hotpot {
         }
 
         $choices = [
-            LOCAL_RECOMPLETION_NOTHING => get_string('donothing', 'local_recompletion'),
-            LOCAL_RECOMPLETION_DELETE => get_string('delete', 'local_recompletion')
+                LOCAL_RECOMPLETION_NOTHING => get_string('donothing', 'local_recompletion'),
+                LOCAL_RECOMPLETION_DELETE => get_string('delete', 'local_recompletion'),
         ];
 
         $settings->add(new admin_setting_configselect('local_recompletion/hotpot',
@@ -86,7 +86,7 @@ class mod_hotpot {
                 new lang_string('hotpotattempts_help', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING, $choices));
 
         $settings->add(new admin_setting_configcheckbox('local_recompletion/archivehotpot',
-            new lang_string('archivehotpot', 'local_recompletion'), '', 1));
+                new lang_string('archivehotpot', 'local_recompletion'), '', 1));
     }
 
     /**
@@ -109,8 +109,8 @@ class mod_hotpot {
 
         if ($config->hotpot == LOCAL_RECOMPLETION_DELETE) {
             $params = [
-                'userid' => $userid,
-                'course' => $course->id
+                    'userid' => $userid,
+                    'course' => $course->id,
             ];
 
             $attemptsselectsql = 'userid = :userid AND hotpotid IN (SELECT id FROM {hotpot} WHERE course = :course)';
@@ -132,6 +132,7 @@ class mod_hotpot {
 
     /**
      * Helper function to check if the plugin is installed.
+     *
      * @return bool
      */
     public static function installed(): bool {

--- a/classes/plugins/mod_hvp.php
+++ b/classes/plugins/mod_hvp.php
@@ -25,7 +25,7 @@ use MoodleQuickForm;
 
 defined('MOODLE_INTERNAL') || die;
 
-require_once($CFG->dirroot.'/local/recompletion/locallib.php');
+require_once($CFG->dirroot . '/local/recompletion/locallib.php');
 
 /**
  * H5P handler event.
@@ -77,8 +77,8 @@ class mod_hvp {
         }
 
         $choices = [
-            LOCAL_RECOMPLETION_NOTHING => get_string('donothing', 'local_recompletion'),
-            LOCAL_RECOMPLETION_DELETE => get_string('delete', 'local_recompletion')
+                LOCAL_RECOMPLETION_NOTHING => get_string('donothing', 'local_recompletion'),
+                LOCAL_RECOMPLETION_DELETE => get_string('delete', 'local_recompletion'),
         ];
 
         $settings->add(new admin_setting_configselect('local_recompletion/hvp',
@@ -86,7 +86,7 @@ class mod_hvp {
                 new lang_string('hvpattempts_help', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING, $choices));
 
         $settings->add(new admin_setting_configcheckbox('local_recompletion/archivehvp',
-            new lang_string('archivehvp', 'local_recompletion'), '', 1));
+                new lang_string('archivehvp', 'local_recompletion'), '', 1));
     }
 
     /**
@@ -109,8 +109,8 @@ class mod_hvp {
 
         if ($config->hvp == LOCAL_RECOMPLETION_DELETE) {
             $params = [
-                'userid' => $userid,
-                'course' => $course->id
+                    'userid' => $userid,
+                    'course' => $course->id,
             ];
 
             $selectsql = 'user_id = :userid AND hvp_id IN (SELECT id FROM {hvp} WHERE course = :course)';
@@ -129,6 +129,7 @@ class mod_hvp {
 
     /**
      * Helper function to check if the plugin is installed.
+     *
      * @return bool
      */
     public static function installed(): bool {

--- a/classes/plugins/mod_lesson.php
+++ b/classes/plugins/mod_lesson.php
@@ -25,7 +25,7 @@ use MoodleQuickForm;
 
 defined('MOODLE_INTERNAL') || die;
 
-require_once($CFG->dirroot.'/local/recompletion/locallib.php');
+require_once($CFG->dirroot . '/local/recompletion/locallib.php');
 
 /**
  * Lesson handler event.
@@ -69,8 +69,8 @@ class mod_lesson {
      */
     public static function settings(admin_settingpage $settings): void {
         $choices = [
-            LOCAL_RECOMPLETION_NOTHING => get_string('donothing', 'local_recompletion'),
-            LOCAL_RECOMPLETION_DELETE => get_string('delete', 'local_recompletion')
+                LOCAL_RECOMPLETION_NOTHING => get_string('donothing', 'local_recompletion'),
+                LOCAL_RECOMPLETION_DELETE => get_string('delete', 'local_recompletion'),
         ];
 
         $settings->add(new admin_setting_configselect('local_recompletion/lesson',
@@ -78,7 +78,7 @@ class mod_lesson {
                 new lang_string('lessonattempts_help', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING, $choices));
 
         $settings->add(new admin_setting_configcheckbox('local_recompletion/archivelesson',
-            new lang_string('archivelesson', 'local_recompletion'), '', 1));
+                new lang_string('archivelesson', 'local_recompletion'), '', 1));
     }
 
     /**
@@ -98,11 +98,11 @@ class mod_lesson {
         if ($config->lesson == LOCAL_RECOMPLETION_DELETE) {
 
             $tables = [
-                'lesson_attempts' => 'local_recompletion_la',
-                'lesson_grades' => 'local_recompletion_lg',
-                'lesson_timer' => 'local_recompletion_lt',
-                'lesson_branch' => 'local_recompletion_lb',
-                'lesson_overrides' => 'local_recompletion_lo',
+                    'lesson_attempts' => 'local_recompletion_la',
+                    'lesson_grades' => 'local_recompletion_lg',
+                    'lesson_timer' => 'local_recompletion_lt',
+                    'lesson_branch' => 'local_recompletion_lb',
+                    'lesson_overrides' => 'local_recompletion_lo',
             ];
 
             $params = ['userid' => $userid, 'course' => $course->id];

--- a/classes/plugins/mod_lti.php
+++ b/classes/plugins/mod_lti.php
@@ -25,7 +25,11 @@
 
 namespace local_recompletion\plugins;
 
+use coding_exception;
+use context_course;
+use dml_exception;
 use lang_string;
+use stdClass;
 
 /**
  * lti handler event.
@@ -39,26 +43,27 @@ use lang_string;
 class mod_lti {
     /**
      * Add params to form.
+     *
      * @param moodleform $mform
-     * @throws \coding_exception
-     * @throws \dml_exception
+     * @throws coding_exception
+     * @throws dml_exception
      */
-    public static function editingform($mform) : void {
+    public static function editingform($mform): void {
         if (!enrol_is_enabled('lti')) {
             return;
         }
 
         $options = [];
         $options[] = $mform->createElement('radio', 'lti', '',
-            get_string('donothing', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING);
+                get_string('donothing', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING);
         $options[] = $mform->createElement('radio', 'lti', '',
-            get_string('resetlti', 'local_recompletion'), LOCAL_RECOMPLETION_DELETE);
+                get_string('resetlti', 'local_recompletion'), LOCAL_RECOMPLETION_DELETE);
 
         $mform->addGroup($options, 'lti', get_string('resetltis', 'local_recompletion'), [' '], false);
         $mform->addHelpButton('lti', 'resetltis', 'local_recompletion');
 
         $mform->addElement('checkbox', 'archivelti',
-            get_string('archive', 'local_recompletion'));
+                get_string('archive', 'local_recompletion'));
         $mform->setDefault('archivelti', get_config('local_recompletion', 'archivelti'));
 
         $mform->disabledIf('lti', 'enable', 'notchecked');
@@ -78,14 +83,14 @@ class mod_lti {
     /**
      * Reset lti grade
      *
-     * @param int       $userid
-     * @param \stdClass $course
-     * @param \stdClass $config
+     * @param int $userid
+     * @param stdClass $course
+     * @param stdClass $config
      *
-     * @throws \coding_exception
-     * @throws \dml_exception
+     * @throws coding_exception
+     * @throws dml_exception
      */
-    public static function reset(int $userid, \stdClass $course, \stdClass $config) : void {
+    public static function reset(int $userid, stdClass $course, stdClass $config): void {
         global $DB;
 
         if (empty($config->lti)) {
@@ -97,8 +102,8 @@ class mod_lti {
             return;
         }
 
-        $context = \context_course::instance($course->id);
-        $tools = $DB->get_records('enrol_lti_tools', ['contextid' => $context->id] , '' , 'id');
+        $context = context_course::instance($course->id);
+        $tools = $DB->get_records('enrol_lti_tools', ['contextid' => $context->id], '', 'id');
 
         if (empty($tools)) {
             return;
@@ -107,8 +112,8 @@ class mod_lti {
         foreach ($tools as $tool) {
 
             $params = [
-                'userid' => $userid,
-                'toolid' => $tool->id,
+                    'userid' => $userid,
+                    'toolid' => $tool->id,
             ];
 
             if ($config->archivelti) {

--- a/classes/plugins/mod_pulse.php
+++ b/classes/plugins/mod_pulse.php
@@ -25,7 +25,11 @@
 
 namespace local_recompletion\plugins;
 
+use admin_setting_configselect;
+use coding_exception;
+use dml_exception;
 use lang_string;
+use stdClass;
 
 /**
  * Pulse handler event.
@@ -42,8 +46,8 @@ class mod_pulse {
      *
      * @param moodleform $mform
      *
-     * @throws \coding_exception
-     * @throws \dml_exception
+     * @throws coding_exception
+     * @throws dml_exception
      */
     public static function editingform($mform): void {
         if (!self::installed()) {
@@ -51,13 +55,13 @@ class mod_pulse {
         }
         $config = get_config('local_recompletion');
 
-        $cba = array();
+        $cba = [];
         $cba[] = $mform->createElement('radio', 'pulse', '',
                 get_string('donothing', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING);
         $cba[] = $mform->createElement('radio', 'pulse', '',
                 get_string('pulseresetnotifications', 'local_recompletion'), LOCAL_RECOMPLETION_DELETE);
 
-        $mform->addGroup($cba, 'pulse', get_string('pulsenotifications', 'local_recompletion'), array(' '), false);
+        $mform->addGroup($cba, 'pulse', get_string('pulsenotifications', 'local_recompletion'), [' '], false);
         $mform->addHelpButton('pulse', 'pulsenotifications', 'local_recompletion');
         $mform->setDefault('pulse', $config->pulse);
     }
@@ -71,9 +75,9 @@ class mod_pulse {
         if (!self::installed()) {
             return;
         }
-        $choices = array(LOCAL_RECOMPLETION_NOTHING => get_string('donothing', 'local_recompletion'),
-                LOCAL_RECOMPLETION_DELETE => get_string('pulseresetnotifications', 'local_recompletion'));
-        $settings->add(new \admin_setting_configselect('local_recompletion/pulse',
+        $choices = [LOCAL_RECOMPLETION_NOTHING => get_string('donothing', 'local_recompletion'),
+                LOCAL_RECOMPLETION_DELETE => get_string('pulseresetnotifications', 'local_recompletion')];
+        $settings->add(new admin_setting_configselect('local_recompletion/pulse',
                 new lang_string('pulsenotifications', 'local_recompletion'),
                 new lang_string('pulsenotifications_help', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING, $choices));
     }
@@ -81,9 +85,9 @@ class mod_pulse {
     /**
      * Reset pulse notification records.
      *
-     * @param \stdclass $userid - user id
-     * @param \stdClass $course - course record.
-     * @param \stdClass $config - recompletion config.
+     * @param stdclass $userid - user id
+     * @param stdClass $course - course record.
+     * @param stdClass $config - recompletion config.
      */
     public static function reset($userid, $course, $config) {
         global $CFG, $DB;
@@ -95,7 +99,7 @@ class mod_pulse {
             return;
         } else if ($config->pulse == LOCAL_RECOMPLETION_DELETE) {
             // Prepare SQL Query.
-            $params = array('userid' => $userid, 'course' => $course->id);
+            $params = ['userid' => $userid, 'course' => $course->id];
             $selectsql = 'userid = ? AND pulseid IN (SELECT id FROM {pulse} WHERE course = ?)';
 
             // Delete records from pulse_users.
@@ -110,11 +114,12 @@ class mod_pulse {
 
     /**
      * Helper function to check if pulse is installed.
+     *
      * @return bool
      */
     public static function installed() {
         global $CFG;
-        if (!file_exists($CFG->dirroot.'/mod/pulse/version.php')) {
+        if (!file_exists($CFG->dirroot . '/mod/pulse/version.php')) {
             return false;
         }
         return true;

--- a/classes/plugins/mod_questionnaire.php
+++ b/classes/plugins/mod_questionnaire.php
@@ -25,7 +25,12 @@
 
 namespace local_recompletion\plugins;
 
+use admin_setting_configcheckbox;
+use admin_setting_configselect;
+use coding_exception;
+use dml_exception;
 use lang_string;
+use stdClass;
 
 /**
  * Questionnaire handler event.
@@ -39,28 +44,29 @@ use lang_string;
 class mod_questionnaire {
     /**
      * Add params to form.
+     *
      * @param moodleform $mform
-     * @throws \coding_exception
-     * @throws \dml_exception
+     * @throws coding_exception
+     * @throws dml_exception
      */
-    public static function editingform($mform) : void {
+    public static function editingform($mform): void {
         if (!self::installed()) {
             return;
         }
         $config = get_config('local_recompletion');
 
-        $cba = array();
+        $cba = [];
         $cba[] = $mform->createElement('radio', 'questionnaire', '',
-            get_string('donothing', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING);
+                get_string('donothing', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING);
         $cba[] = $mform->createElement('radio', 'questionnaire', '',
-            get_string('delete', 'local_recompletion'), LOCAL_RECOMPLETION_DELETE);
+                get_string('delete', 'local_recompletion'), LOCAL_RECOMPLETION_DELETE);
 
-        $mform->addGroup($cba, 'questionnaire', get_string('questionnaireattempts', 'local_recompletion'), array(' '), false);
+        $mform->addGroup($cba, 'questionnaire', get_string('questionnaireattempts', 'local_recompletion'), [' '], false);
         $mform->addHelpButton('questionnaire', 'questionnaireattempts', 'local_recompletion');
         $mform->setDefault('questionnaire', $config->questionnaire);
 
         $mform->addElement('checkbox', 'archivequestionnaire',
-            get_string('archive', 'local_recompletion'));
+                get_string('archive', 'local_recompletion'));
         $mform->setDefault('archivequestionnaire', $config->archivequestionnaire);
 
         $mform->disabledIf('questionnaire', 'enable', 'notchecked');
@@ -77,41 +83,42 @@ class mod_questionnaire {
         if (!self::installed()) {
             return;
         }
-        $choices = array(LOCAL_RECOMPLETION_NOTHING => new lang_string('donothing', 'local_recompletion'),
-            LOCAL_RECOMPLETION_DELETE => new lang_string('delete', 'local_recompletion'),
-            LOCAL_RECOMPLETION_EXTRAATTEMPT => new lang_string('extraattempt', 'local_recompletion'));
+        $choices = [LOCAL_RECOMPLETION_NOTHING => new lang_string('donothing', 'local_recompletion'),
+                LOCAL_RECOMPLETION_DELETE => new lang_string('delete', 'local_recompletion'),
+                LOCAL_RECOMPLETION_EXTRAATTEMPT => new lang_string('extraattempt', 'local_recompletion')];
 
-        $settings->add(new \admin_setting_configselect('local_recompletion/questionnaire',
-            new lang_string('questionnaireattempts', 'local_recompletion'),
-            new lang_string('questionnaireattempts_help', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING, $choices));
+        $settings->add(new admin_setting_configselect('local_recompletion/questionnaire',
+                new lang_string('questionnaireattempts', 'local_recompletion'),
+                new lang_string('questionnaireattempts_help', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING, $choices));
 
-        $settings->add(new \admin_setting_configcheckbox('local_recompletion/archivequestionnaire',
-            new lang_string('archivequestionnaire', 'local_recompletion'), '', 1));
+        $settings->add(new admin_setting_configcheckbox('local_recompletion/archivequestionnaire',
+                new lang_string('archivequestionnaire', 'local_recompletion'), '', 1));
     }
 
     /**
      * Reset and archive questionnaire records.
-     * @param \int $userid - userid
-     * @param \stdclass $course - course record.
-     * @param \stdClass $config - recompletion config.
+     *
+     * @param int $userid - userid
+     * @param stdclass $course - course record.
+     * @param stdClass $config - recompletion config.
      */
     public static function reset($userid, $course, $config) {
         global $DB;
         if (!self::installed()) {
             return;
         }
-        $extratables = ['local_recompletion_qr_bool'   => 'questionnaire_response_bool' ,
-                        'local_recompletion_qr_date'   => 'questionnaire_response_date',
-                        'local_recompletion_qr_m'      => 'questionnaire_resp_multiple',
-                        'local_recompletion_qr_other'  => 'questionnaire_response_other',
-                        'local_recompletion_qr_rank'   => 'questionnaire_response_rank',
-                        'local_recompletion_qr_single' => 'questionnaire_resp_single',
-                        'local_recompletion_qr_text'   => 'questionnaire_response_text'];
+        $extratables = ['local_recompletion_qr_bool' => 'questionnaire_response_bool',
+                'local_recompletion_qr_date' => 'questionnaire_response_date',
+                'local_recompletion_qr_m' => 'questionnaire_resp_multiple',
+                'local_recompletion_qr_other' => 'questionnaire_response_other',
+                'local_recompletion_qr_rank' => 'questionnaire_response_rank',
+                'local_recompletion_qr_single' => 'questionnaire_resp_single',
+                'local_recompletion_qr_text' => 'questionnaire_response_text'];
 
         if (empty($config->questionnaire)) {
             return;
         } else if ($config->questionnaire == LOCAL_RECOMPLETION_DELETE) {
-            $params = array('userid' => $userid, 'course' => $course->id);
+            $params = ['userid' => $userid, 'course' => $course->id];
             $selectsql = 'userid = ? AND questionnaireid IN (SELECT id FROM {questionnaire} WHERE course = ?)';
 
             $questionnaireattempts = $DB->get_records_select('questionnaire_response', $selectsql, $params);
@@ -146,11 +153,12 @@ class mod_questionnaire {
 
     /**
      * Helper function to check if questionnaire is installed.
+     *
      * @return bool
      */
     public static function installed() {
         global $CFG;
-        if (!file_exists($CFG->dirroot.'/mod/questionnaire/version.php')) {
+        if (!file_exists($CFG->dirroot . '/mod/questionnaire/version.php')) {
             return false;
         }
         return true;

--- a/classes/plugins/mod_quiz.php
+++ b/classes/plugins/mod_quiz.php
@@ -25,7 +25,16 @@
 
 namespace local_recompletion\plugins;
 
+use admin_setting_configcheckbox;
+use admin_setting_configselect;
+use coding_exception;
+use context_module;
+use dml_exception;
 use lang_string;
+use mod_quiz\event\user_override_created;
+use mod_quiz\event\user_override_updated;
+use stdClass;
+use function quiz_get_user_attempts;
 
 /**
  * Quiz handler event.
@@ -39,31 +48,32 @@ use lang_string;
 class mod_quiz {
     /**
      * Add params to form.
+     *
      * @param moodleform $mform
-     * @throws \coding_exception
-     * @throws \dml_exception
+     * @throws coding_exception
+     * @throws dml_exception
      */
-    public static function editingform($mform) : void {
+    public static function editingform($mform): void {
         $config = get_config('local_recompletion');
 
-        $cba = array();
+        $cba = [];
         $cba[] = $mform->createElement('radio', 'quiz', '',
-            get_string('donothing', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING);
+                get_string('donothing', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING);
         $cba[] = $mform->createElement('radio', 'quiz', '',
-            get_string('delete', 'local_recompletion'), LOCAL_RECOMPLETION_DELETE);
+                get_string('delete', 'local_recompletion'), LOCAL_RECOMPLETION_DELETE);
         $cba[] = $mform->createElement('radio', 'quiz', '',
-            get_string('extraattempt', 'local_recompletion'), LOCAL_RECOMPLETION_EXTRAATTEMPT);
+                get_string('extraattempt', 'local_recompletion'), LOCAL_RECOMPLETION_EXTRAATTEMPT);
 
-        $mform->addGroup($cba, 'quiz', get_string('quizattempts', 'local_recompletion'), array(' '), false);
+        $mform->addGroup($cba, 'quiz', get_string('quizattempts', 'local_recompletion'), [' '], false);
         $mform->addHelpButton('quiz', 'quizattempts', 'local_recompletion');
         $mform->setDefault('quiz', $config->quiz);
 
         $mform->addElement('checkbox', 'archivequiz',
-            get_string('archive', 'local_recompletion'));
+                get_string('archive', 'local_recompletion'));
         $mform->setDefault('archivequiz', $config->archivequiz);
 
         $mform->addElement('checkbox', 'resetquizoverride',
-            get_string('resetquizoverride', 'local_recompletion'));
+                get_string('resetquizoverride', 'local_recompletion'));
         $mform->setDefault('resetquizoverride', $config->resetquizoverride);
 
         $mform->disabledIf('quiz', 'enable', 'notchecked');
@@ -79,33 +89,34 @@ class mod_quiz {
      * @param admin_settingpage $settings
      */
     public static function settings($settings) {
-        $choices = array(LOCAL_RECOMPLETION_NOTHING => new lang_string('donothing', 'local_recompletion'),
-                         LOCAL_RECOMPLETION_DELETE => new lang_string('delete', 'local_recompletion'),
-                         LOCAL_RECOMPLETION_EXTRAATTEMPT => new lang_string('extraattempt', 'local_recompletion'));
+        $choices = [LOCAL_RECOMPLETION_NOTHING => new lang_string('donothing', 'local_recompletion'),
+                LOCAL_RECOMPLETION_DELETE => new lang_string('delete', 'local_recompletion'),
+                LOCAL_RECOMPLETION_EXTRAATTEMPT => new lang_string('extraattempt', 'local_recompletion')];
 
-        $settings->add(new \admin_setting_configselect('local_recompletion/quiz',
-            new lang_string('quizattempts', 'local_recompletion'),
-            new lang_string('quizattempts_help', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING, $choices));
+        $settings->add(new admin_setting_configselect('local_recompletion/quiz',
+                new lang_string('quizattempts', 'local_recompletion'),
+                new lang_string('quizattempts_help', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING, $choices));
 
-        $settings->add(new \admin_setting_configcheckbox('local_recompletion/archivequiz',
-            new lang_string('archivequiz', 'local_recompletion'), '', 1));
+        $settings->add(new admin_setting_configcheckbox('local_recompletion/archivequiz',
+                new lang_string('archivequiz', 'local_recompletion'), '', 1));
 
-        $settings->add(new \admin_setting_configcheckbox('local_recompletion/resetquizoverride',
-            new lang_string('resetquizoverride', 'local_recompletion'), '', 0));
+        $settings->add(new admin_setting_configcheckbox('local_recompletion/resetquizoverride',
+                new lang_string('resetquizoverride', 'local_recompletion'), '', 0));
     }
 
     /**
      * Reset and archive quiz records.
-     * @param \int $userid - userid
-     * @param \stdclass $course - course record.
-     * @param \stdClass $config - recompletion config.
+     *
+     * @param int $userid - userid
+     * @param stdclass $course - course record.
+     * @param stdClass $config - recompletion config.
      */
     public static function reset($userid, $course, $config) {
         global $DB;
         if (empty($config->quiz)) {
             return;
         } else if ($config->quiz == LOCAL_RECOMPLETION_DELETE) {
-            $params = array('userid' => $userid, 'course' => $course->id);
+            $params = ['userid' => $userid, 'course' => $course->id];
             $selectsql = 'userid = ? AND quiz IN (SELECT id FROM {quiz} WHERE course = ?)';
             if ($config->archivequiz) {
                 $quizattempts = $DB->get_records_select('quiz_attempts', $selectsql, $params);
@@ -133,10 +144,10 @@ class mod_quiz {
                       FROM {quiz} q
                       JOIN {quiz_attempts} qa ON q.id = qa.quiz
                      WHERE q.attempts > 0 AND q.course = ? AND qa.userid = ?";
-            $quizzes = $DB->get_recordset_sql( $sql, array($course->id, $userid));
+            $quizzes = $DB->get_recordset_sql($sql, [$course->id, $userid]);
             foreach ($quizzes as $quiz) {
                 // Get number of this users attempts.
-                $attempts = \quiz_get_user_attempts($quiz->id, $userid);
+                $attempts = quiz_get_user_attempts($quiz->id, $userid);
                 $countattempts = count($attempts);
 
                 // Allow the user to have the same number of attempts at this quiz as they initially did.
@@ -145,34 +156,34 @@ class mod_quiz {
 
                 // Get stuff needed for the events.
                 $cm = get_coursemodule_from_instance('quiz', $quiz->id);
-                $context = \context_module::instance($cm->id);
+                $context = context_module::instance($cm->id);
 
-                $eventparams = array(
-                    'context' => $context,
-                    'other' => array(
-                        'quizid' => $quiz->id
-                    ),
-                    'relateduserid' => $userid
-                );
+                $eventparams = [
+                        'context' => $context,
+                        'other' => [
+                                'quizid' => $quiz->id,
+                        ],
+                        'relateduserid' => $userid,
+                ];
 
-                $conditions = array(
-                    'quiz' => $quiz->id,
-                    'userid' => $userid);
+                $conditions = [
+                        'quiz' => $quiz->id,
+                        'userid' => $userid];
                 if ($oldoverride = $DB->get_record('quiz_overrides', $conditions)) {
                     if ($oldoverride->attempts < $nowallowed) {
                         $oldoverride->attempts = $nowallowed;
                         $DB->update_record('quiz_overrides', $oldoverride);
                         $eventparams['objectid'] = $oldoverride->id;
-                        $event = \mod_quiz\event\user_override_updated::create($eventparams);
+                        $event = user_override_updated::create($eventparams);
                         $event->trigger();
                     }
                 } else {
-                    $data = new \stdClass();
+                    $data = new stdClass();
                     $data->attempts = $nowallowed;
                     $data->quiz = $quiz->id;
                     $data->userid = $userid;
                     // Merge quiz defaults with data.
-                    $keys = array('timeopen', 'timeclose', 'timelimit', 'password');
+                    $keys = ['timeopen', 'timeclose', 'timelimit', 'password'];
                     foreach ($keys as $key) {
                         if (!isset($data->{$key})) {
                             $data->{$key} = $quiz->{$key};
@@ -180,7 +191,7 @@ class mod_quiz {
                     }
                     $newid = $DB->insert_record('quiz_overrides', $data);
                     $eventparams['objectid'] = $newid;
-                    $event = \mod_quiz\event\user_override_created::create($eventparams);
+                    $event = user_override_created::create($eventparams);
                     $event->trigger();
                 }
             }

--- a/classes/plugins/mod_scorm.php
+++ b/classes/plugins/mod_scorm.php
@@ -25,7 +25,12 @@
 
 namespace local_recompletion\plugins;
 
+use admin_setting_configcheckbox;
+use admin_setting_configselect;
+use coding_exception;
+use dml_exception;
 use lang_string;
+use stdClass;
 
 /**
  * SCORM handler event.
@@ -39,25 +44,26 @@ use lang_string;
 class mod_scorm {
     /**
      * Add params to form.
+     *
      * @param moodleform $mform
-     * @throws \coding_exception
-     * @throws \dml_exception
+     * @throws coding_exception
+     * @throws dml_exception
      */
-    public static function editingform($mform) : void {
+    public static function editingform($mform): void {
         $config = get_config('local_recompletion');
 
-        $cba = array();
+        $cba = [];
         $cba[] = $mform->createElement('radio', 'scorm', '',
-            get_string('donothing', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING);
+                get_string('donothing', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING);
         $cba[] = $mform->createElement('radio', 'scorm', '',
-            get_string('delete', 'local_recompletion'), LOCAL_RECOMPLETION_DELETE);
+                get_string('delete', 'local_recompletion'), LOCAL_RECOMPLETION_DELETE);
 
-        $mform->addGroup($cba, 'scorm', get_string('scormattempts', 'local_recompletion'), array(' '), false);
+        $mform->addGroup($cba, 'scorm', get_string('scormattempts', 'local_recompletion'), [' '], false);
         $mform->addHelpButton('scorm', 'scormattempts', 'local_recompletion');
         $mform->setDefault('scorm', $config->scorm);
 
         $mform->addElement('checkbox', 'archivescorm',
-            get_string('archive', 'local_recompletion'));
+                get_string('archive', 'local_recompletion'));
         $mform->setDefault('archivescorm', $config->archivescorm);
 
         $mform->disabledIf('archivescorm', 'enable', 'notchecked');
@@ -72,21 +78,22 @@ class mod_scorm {
      * @param admin_settingpage $settings
      */
     public static function settings($settings) {
-        $choices = array(LOCAL_RECOMPLETION_NOTHING => get_string('donothing', 'local_recompletion'),
-            LOCAL_RECOMPLETION_DELETE => get_string('delete', 'local_recompletion'));
-        $settings->add(new \admin_setting_configselect('local_recompletion/scorm',
-            new lang_string('scormattempts', 'local_recompletion'),
-            new lang_string('scormattempts_help', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING, $choices));
+        $choices = [LOCAL_RECOMPLETION_NOTHING => get_string('donothing', 'local_recompletion'),
+                LOCAL_RECOMPLETION_DELETE => get_string('delete', 'local_recompletion')];
+        $settings->add(new admin_setting_configselect('local_recompletion/scorm',
+                new lang_string('scormattempts', 'local_recompletion'),
+                new lang_string('scormattempts_help', 'local_recompletion'), LOCAL_RECOMPLETION_NOTHING, $choices));
 
-        $settings->add(new \admin_setting_configcheckbox('local_recompletion/archivescorm',
-            new lang_string('archivescorm', 'local_recompletion'), '', 1));
+        $settings->add(new admin_setting_configcheckbox('local_recompletion/archivescorm',
+                new lang_string('archivescorm', 'local_recompletion'), '', 1));
     }
 
     /**
      * Reset and archive scorm records.
-     * @param \stdclass $userid - user id
-     * @param \stdClass $course - course record.
-     * @param \stdClass $config - recompletion config.
+     *
+     * @param stdclass $userid - user id
+     * @param stdClass $course - course record.
+     * @param stdClass $config - recompletion config.
      */
     public static function reset($userid, $course, $config) {
         global $DB;
@@ -94,7 +101,7 @@ class mod_scorm {
         if (empty($config->scorm)) {
             return;
         } else if ($config->scorm == LOCAL_RECOMPLETION_DELETE) {
-            $params = array('userid' => $userid, 'course' => $course->id);
+            $params = ['userid' => $userid, 'course' => $course->id];
             $selectsql = 'userid = ? AND scormid IN (SELECT id FROM {scorm} WHERE course = ?)';
 
             $scormattempt = $DB->get_records_select('scorm_attempt', $selectsql, $params);

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -26,8 +26,16 @@
 namespace local_recompletion\privacy;
 
 use context;
+use context_course;
 use core_privacy\local\metadata\collection;
-use core_privacy\local\request\{writer, transform, helper, contextlist, approved_contextlist, approved_userlist, userlist};
+use core_privacy\local\request\{core_userlist_provider,
+        writer,
+        transform,
+        helper,
+        contextlist,
+        approved_contextlist,
+        approved_userlist,
+        userlist};
 use stdClass;
 
 /**
@@ -38,9 +46,9 @@ use stdClass;
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class provider implements
-    \core_privacy\local\request\plugin\provider,
-    \core_privacy\local\request\core_userlist_provider,
-    \core_privacy\local\metadata\provider {
+        \core_privacy\local\request\plugin\provider,
+        core_userlist_provider,
+        \core_privacy\local\metadata\provider {
 
     /**
      * Returns meta data about this system.
@@ -48,160 +56,160 @@ class provider implements
      * @param collection $collection The initialised collection to add items to.
      * @return collection A listing of user data stored through this system.
      */
-    public static function get_metadata(collection $collection) : collection {
+    public static function get_metadata(collection $collection): collection {
         $collection->add_database_table('local_recompletion_cc', [
-            'userid' => 'privacy:metadata:userid',
-            'course' => 'privacy:metadata:course',
-            'timeenrolled' => 'privacy:metadata:timeenrolled',
-            'timestarted' => 'privacy:metadata:timestarted',
-            'timecompleted' => 'privacy:metadata:timecompleted',
-            'reaggregate' => 'privacy:metadata:reaggregate'
+                'userid' => 'privacy:metadata:userid',
+                'course' => 'privacy:metadata:course',
+                'timeenrolled' => 'privacy:metadata:timeenrolled',
+                'timestarted' => 'privacy:metadata:timestarted',
+                'timecompleted' => 'privacy:metadata:timecompleted',
+                'reaggregate' => 'privacy:metadata:reaggregate',
         ], 'privacy:metadata:local_recompletion_cc');
 
         $collection->add_database_table('local_recompletion_cmc', [
-            'userid' => 'privacy:metadata:userid',
-            'coursemoduleid' => 'privacy:metadata:coursemoduleid',
-            'completionstate' => 'privacy:metadata:completionstate',
-            'viewed' => 'privacy:metadata:viewed',
-            'overrideby' => 'privacy:metadata:overrideby',
-            'timemodified' => 'privacy:metadata:timemodified'
+                'userid' => 'privacy:metadata:userid',
+                'coursemoduleid' => 'privacy:metadata:coursemoduleid',
+                'completionstate' => 'privacy:metadata:completionstate',
+                'viewed' => 'privacy:metadata:viewed',
+                'overrideby' => 'privacy:metadata:overrideby',
+                'timemodified' => 'privacy:metadata:timemodified',
         ], 'privacy:metadata:local_recompletion_cmc');
 
         $collection->add_database_table('local_recompletion_cmv', [
-            'userid' => 'privacy:metadata:userid',
-            'coursemoduleid' => 'privacy:metadata:coursemoduleid',
-            'timemodified' => 'privacy:metadata:timemodified'
+                'userid' => 'privacy:metadata:userid',
+                'coursemoduleid' => 'privacy:metadata:coursemoduleid',
+                'timemodified' => 'privacy:metadata:timemodified',
         ], 'privacy:metadata:local_recompletion_cmv');
 
         $collection->add_database_table('local_recompletion_cc_cc', [
-            'userid' => 'privacy:metadata:userid',
-            'course' => 'privacy:metadata:course',
-            'gradefinal' => 'privacy:metadata:gradefinal',
-            'unenroled' => 'privacy:metadata:unenroled',
-            'timecompleted' => 'privacy:metadata:timecompleted'
+                'userid' => 'privacy:metadata:userid',
+                'course' => 'privacy:metadata:course',
+                'gradefinal' => 'privacy:metadata:gradefinal',
+                'unenroled' => 'privacy:metadata:unenroled',
+                'timecompleted' => 'privacy:metadata:timecompleted',
         ], 'privacy:metadata:local_recompletion_cc_cc');
 
         $collection->add_database_table('local_recompletion_qa', [
-            'attempt'               => 'privacy:metadata:quiz_attempts:attempt',
-            'currentpage'           => 'privacy:metadata:quiz_attempts:currentpage',
-            'preview'               => 'privacy:metadata:quiz_attempts:preview',
-            'state'                 => 'privacy:metadata:quiz_attempts:state',
-            'timestart'             => 'privacy:metadata:quiz_attempts:timestart',
-            'timefinish'            => 'privacy:metadata:quiz_attempts:timefinish',
-            'timemodified'          => 'privacy:metadata:quiz_attempts:timemodified',
-            'timemodifiedoffline'   => 'privacy:metadata:quiz_attempts:timemodifiedoffline',
-            'timecheckstate'        => 'privacy:metadata:quiz_attempts:timecheckstate',
-            'sumgrades'             => 'privacy:metadata:quiz_attempts:sumgrades',
+                'attempt' => 'privacy:metadata:quiz_attempts:attempt',
+                'currentpage' => 'privacy:metadata:quiz_attempts:currentpage',
+                'preview' => 'privacy:metadata:quiz_attempts:preview',
+                'state' => 'privacy:metadata:quiz_attempts:state',
+                'timestart' => 'privacy:metadata:quiz_attempts:timestart',
+                'timefinish' => 'privacy:metadata:quiz_attempts:timefinish',
+                'timemodified' => 'privacy:metadata:quiz_attempts:timemodified',
+                'timemodifiedoffline' => 'privacy:metadata:quiz_attempts:timemodifiedoffline',
+                'timecheckstate' => 'privacy:metadata:quiz_attempts:timecheckstate',
+                'sumgrades' => 'privacy:metadata:quiz_attempts:sumgrades',
         ], 'privacy:metadata:quiz_attempts');
 
         $collection->add_database_table('local_recompletion_qg', [
-            'quiz'                  => 'privacy:metadata:quiz_grades:quiz',
-            'userid'                => 'privacy:metadata:quiz_grades:userid',
-            'grade'                 => 'privacy:metadata:quiz_grades:grade',
-            'timemodified'          => 'privacy:metadata:quiz_grades:timemodified',
+                'quiz' => 'privacy:metadata:quiz_grades:quiz',
+                'userid' => 'privacy:metadata:quiz_grades:userid',
+                'grade' => 'privacy:metadata:quiz_grades:grade',
+                'timemodified' => 'privacy:metadata:quiz_grades:timemodified',
         ], 'privacy:metadata:quiz_grades');
 
         $collection->add_database_table('local_recompletion_sa', [
-            'userid' => 'privacy:metadata:userid',
-            'scormid' => 'privacy:metadata:scormid',
-            'courseid' => 'privacy:metadata:course',
+                'userid' => 'privacy:metadata:userid',
+                'scormid' => 'privacy:metadata:scormid',
+                'courseid' => 'privacy:metadata:course',
         ], 'privacy:metadata:scorm_attempt');
 
         $collection->add_database_table('local_recompletion_ssv', [
-            'userid' => 'privacy:metadata:userid',
-            'attemptid' => 'privacy:metadata:attempt',
-            'elementid' => 'privacy:metadata:scoes_value:element',
-            'value' => 'privacy:metadata:scoes_value:value',
-            'timemodified' => 'privacy:metadata:timemodified',
-            'courseid' => 'privacy:metadata:course'
+                'userid' => 'privacy:metadata:userid',
+                'attemptid' => 'privacy:metadata:attempt',
+                'elementid' => 'privacy:metadata:scoes_value:element',
+                'value' => 'privacy:metadata:scoes_value:value',
+                'timemodified' => 'privacy:metadata:timemodified',
+                'courseid' => 'privacy:metadata:course',
         ], 'privacy:metadata:scorm_scoes_value');
 
         $collection->add_database_table('local_recompletion_ltia', [
-            'toolid' => 'privacy:metadata:local_recompletion_ltia:toolid',
-            'userid' => 'privacy:metadata:local_recompletion_ltia:userid',
-            'lastgrade' => 'privacy:metadata:local_recompletion_ltia:lastgrade',
-            'lastaccess' => 'privacy:metadata:local_recompletion_ltia:lastaccess',
-            'timecreated' => 'privacy:metadata:local_recompletion_ltia:timecreated',
+                'toolid' => 'privacy:metadata:local_recompletion_ltia:toolid',
+                'userid' => 'privacy:metadata:local_recompletion_ltia:userid',
+                'lastgrade' => 'privacy:metadata:local_recompletion_ltia:lastgrade',
+                'lastaccess' => 'privacy:metadata:local_recompletion_ltia:lastaccess',
+                'timecreated' => 'privacy:metadata:local_recompletion_ltia:timecreated',
         ], 'privacy:metadata:local_recompletion_ltia');
 
         $collection->add_database_table('local_recompletion_qr', [
-            'questionnaireid' => 'privacy:metadata:local_recompletion_qr:questionnaireid',
-            'userid' => 'privacy:metadata:userid',
-            'submitted' => 'privacy:metadata:local_recompletion_qr:submitted',
-            'complete' => 'privacy:metadata:local_recompletion_qr:complete',
-            'grade' => 'privacy:metadata:local_recompletion_qr:grade',
+                'questionnaireid' => 'privacy:metadata:local_recompletion_qr:questionnaireid',
+                'userid' => 'privacy:metadata:userid',
+                'submitted' => 'privacy:metadata:local_recompletion_qr:submitted',
+                'complete' => 'privacy:metadata:local_recompletion_qr:complete',
+                'grade' => 'privacy:metadata:local_recompletion_qr:grade',
         ], 'privacy:metadata:local_recompletion_qr');
 
         $collection->add_database_table('local_recompletion_cha', [
-            'choiceid' => 'privacy:metadata:local_recompletion_cha:choiceid',
-            'userid' => 'privacy:metadata:userid',
-            'optionid' => 'privacy:metadata:local_recompletion_cha:optionid',
-            'timemodified' => 'privacy:metadata:timemodified'
+                'choiceid' => 'privacy:metadata:local_recompletion_cha:choiceid',
+                'userid' => 'privacy:metadata:userid',
+                'optionid' => 'privacy:metadata:local_recompletion_cha:optionid',
+                'timemodified' => 'privacy:metadata:timemodified',
         ], 'privacy:metadata:local_recompletion_cha');
 
         $collection->add_database_table('local_recompletion_ccert_is', [
-            'userid' => 'privacy:metadata:userid',
-            'emailed' => 'privacy:metadata:local_recompletion_ccert_is:emailed',
-            'timecreated' => 'privacy:metadata:local_recompletion_ccert_is:timecreated',
-            'course' => 'privacy:metadata:course',
+                'userid' => 'privacy:metadata:userid',
+                'emailed' => 'privacy:metadata:local_recompletion_ccert_is:emailed',
+                'timecreated' => 'privacy:metadata:local_recompletion_ccert_is:timecreated',
+                'course' => 'privacy:metadata:course',
         ], 'privacy:metadata:local_recompletion_ccert_is');
 
         $collection->add_database_table('local_recompletion_hvp', [
-            'user_id' => 'privacy:metadata:userid',
-            'hvp_id' => 'privacy:metadata:local_recompletion_hvp:hvp_id',
-            'data' => 'privacy:metadata:local_recompletion_hvp:data',
-            'course' => 'privacy:metadata:course',
+                'user_id' => 'privacy:metadata:userid',
+                'hvp_id' => 'privacy:metadata:local_recompletion_hvp:hvp_id',
+                'data' => 'privacy:metadata:local_recompletion_hvp:data',
+                'course' => 'privacy:metadata:course',
         ], 'privacy:metadata:local_recompletion_hvp');
 
         $collection->add_database_table('local_recompletion_h5p', [
-            'userid' => 'privacy:metadata:userid',
-            'attempt' => 'privacy:metadata:attempt',
-            'timecreated' => 'privacy:metadata:timecreated',
-            'timemodified' => 'privacy:metadata:timemodified',
-            'rawscore' => 'privacy:metadata:rawscore',
+                'userid' => 'privacy:metadata:userid',
+                'attempt' => 'privacy:metadata:attempt',
+                'timecreated' => 'privacy:metadata:timecreated',
+                'timemodified' => 'privacy:metadata:timemodified',
+                'rawscore' => 'privacy:metadata:rawscore',
         ], 'privacy:metadata:local_recompletion_h5p');
 
         $collection->add_database_table('local_recompletion_h5pr', [
-            'attempt' => 'privacy:metadata:attempt',
-            'timecreated' => 'privacy:metadata:timecreated',
-            'rawscore' => 'privacy:metadata:rawscore',
+                'attempt' => 'privacy:metadata:attempt',
+                'timecreated' => 'privacy:metadata:timecreated',
+                'rawscore' => 'privacy:metadata:rawscore',
         ], 'privacy:metadata:local_recompletion_h5pr');
 
         $collection->add_database_table('local_recompletion_la', [
-            'correct' => 'privacy:metadata:correct',
-            'useranswer' => 'privacy:metadata:useranswer',
+                'correct' => 'privacy:metadata:correct',
+                'useranswer' => 'privacy:metadata:useranswer',
         ], 'privacy:metadata:local_recompletion_la');
 
         $collection->add_database_table('local_recompletion_lg', [
-            'grade' => 'privacy:metadata:grade',
+                'grade' => 'privacy:metadata:grade',
         ], 'privacy:metadata:local_recompletion_lg');
 
         $collection->add_database_table('local_recompletion_lt', [
-            'starttime' => 'privacy:metadata:starttime',
-            'lessontime' => 'privacy:metadata:lessontime',
+                'starttime' => 'privacy:metadata:starttime',
+                'lessontime' => 'privacy:metadata:lessontime',
         ], 'privacy:metadata:local_recompletion_lt');
 
         $collection->add_database_table('local_recompletion_lb', [
-            'flag' => 'privacy:metadata:flag',
+                'flag' => 'privacy:metadata:flag',
         ], 'privacy:metadata:local_recompletion_lb');
 
         $collection->add_database_table('local_recompletion_lo', [
-            'deadline' => 'privacy:metadata:deadline',
-            'maxattempts' => 'privacy:metadata:maxattempts',
-            'retake' => 'privacy:metadata:retake',
+                'deadline' => 'privacy:metadata:deadline',
+                'maxattempts' => 'privacy:metadata:maxattempts',
+                'retake' => 'privacy:metadata:retake',
         ], 'privacy:metadata:local_recompletion_lo');
 
         $collection->add_database_table('local_recompletion_hpa', [
-            'userid' => 'privacy:metadata:userid',
-            'starttime' => 'privacy:metadata:starttime',
-            'endtime' => 'privacy:metadata:endtime',
-            'score' => 'privacy:metadata:score',
+                'userid' => 'privacy:metadata:userid',
+                'starttime' => 'privacy:metadata:starttime',
+                'endtime' => 'privacy:metadata:endtime',
+                'score' => 'privacy:metadata:score',
         ], 'privacy:metadata:local_recompletion_hpa');
 
         $collection->add_database_table('local_recompletion_cert', [
-            'userid' => 'privacy:metadata:userid',
-            'timecreated' => 'privacy:metadata:local_recompletion_cert:timecreated',
-            'course' => 'privacy:metadata:course',
+                'userid' => 'privacy:metadata:userid',
+                'timecreated' => 'privacy:metadata:local_recompletion_cert:timecreated',
+                'course' => 'privacy:metadata:course',
         ], 'privacy:metadata:local_recompletion_cert');
 
         return $collection;
@@ -215,58 +223,58 @@ class provider implements
     public static function export_user_data(approved_contextlist $contextlist) {
         global $DB;
 
-        $userid = (int)$contextlist->get_user()->id;
+        $userid = (int) $contextlist->get_user()->id;
         foreach ($contextlist->get_contexts() as $context) {
-            if (!$context instanceof \context_course) {
+            if (!$context instanceof context_course) {
                 return;
             }
-            $params = array('userid' => $userid, 'course' => $context->instanceid);
+            $params = ['userid' => $userid, 'course' => $context->instanceid];
             $records = $DB->get_records('local_recompletion_cc', $params);
             foreach ($records as $record) {
-                $context = \context_course::instance($record->course);
+                $context = context_course::instance($record->course);
                 writer::with_context($context)->export_data(
-                    [get_string('recompletion', 'local_recompletion'), 'course_completion'],
-                    (object)[array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
+                        [get_string('recompletion', 'local_recompletion'), 'course_completion'],
+                        (object) [array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
             }
 
             $records = $DB->get_records('local_recompletion_cc_cc', $params);
             foreach ($records as $record) {
-                $context = \context_course::instance($record->course);
+                $context = context_course::instance($record->course);
                 writer::with_context($context)->export_data(
-                    [get_string('recompletion', 'local_recompletion'), 'course_completion_criteria_compl'],
-                    (object)[array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
+                        [get_string('recompletion', 'local_recompletion'), 'course_completion_criteria_compl'],
+                        (object) [array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
             }
 
             $records = $DB->get_records('local_recompletion_cmc', $params);
             foreach ($records as $record) {
-                $context = \context_course::instance($record->course);
+                $context = context_course::instance($record->course);
                 writer::with_context($context)->export_data(
-                    [get_string('recompletion', 'local_recompletion'), 'course_module_completion'],
-                    (object)[array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
+                        [get_string('recompletion', 'local_recompletion'), 'course_module_completion'],
+                        (object) [array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
             }
 
             $records = $DB->get_records('local_recompletion_cmv', $params);
             foreach ($records as $record) {
-                $context = \context_course::instance($record->course);
+                $context = context_course::instance($record->course);
                 writer::with_context($context)->export_data(
-                    [get_string('recompletion', 'local_recompletion'), 'course_module_completion'],
-                    (object)[array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
+                        [get_string('recompletion', 'local_recompletion'), 'course_module_completion'],
+                        (object) [array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
             }
 
             $records = $DB->get_records('local_recompletion_qa', $params);
             foreach ($records as $record) {
-                $context = \context_course::instance($record->course);
+                $context = context_course::instance($record->course);
                 writer::with_context($context)->export_data(
-                    [get_string('recompletion', 'local_recompletion'), 'quiz_attempts'],
-                    (object)[array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
+                        [get_string('recompletion', 'local_recompletion'), 'quiz_attempts'],
+                        (object) [array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
             }
 
             $records = $DB->get_records('local_recompletion_qg', $params);
             foreach ($records as $record) {
-                $context = \context_course::instance($record->course);
+                $context = context_course::instance($record->course);
                 writer::with_context($context)->export_data(
-                    [get_string('recompletion', 'local_recompletion'), 'quiz_grades'],
-                    (object)[array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
+                        [get_string('recompletion', 'local_recompletion'), 'quiz_grades'],
+                        (object) [array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
             }
 
             $sql = "SELECT v.id, v.scoid, v.attemptid, e.element, v.courseid, t.timemodified
@@ -275,42 +283,42 @@ class provider implements
                     WHERE v.courseid = :course AND v.userid = :userid";
             $records = $DB->get_records_sql($sql, $params);
             foreach ($records as $record) {
-                $context = \context_course::instance($record->course);
+                $context = context_course::instance($record->course);
                 writer::with_context($context)->export_data(
-                    [get_string('recompletion', 'local_recompletion'), 'scorm_tracks'],
-                    (object)[array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
+                        [get_string('recompletion', 'local_recompletion'), 'scorm_tracks'],
+                        (object) [array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
             }
 
             $records = $DB->get_records('local_recompletion_ltia', ['userid' => $userid]);
             foreach ($records as $record) {
-                $context = \context_course::instance($record->course);
+                $context = context_course::instance($record->course);
                 writer::with_context($context)->export_data(
-                    [get_string('recompletion', 'local_recompletion'), 'enrol_lti_users'],
-                    (object)[array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
+                        [get_string('recompletion', 'local_recompletion'), 'enrol_lti_users'],
+                        (object) [array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
             }
 
             $records = $DB->get_records('local_recompletion_qr', $params);
             foreach ($records as $record) {
-                $context = \context_course::instance($record->course);
+                $context = context_course::instance($record->course);
                 writer::with_context($context)->export_data(
-                    [get_string('recompletion', 'local_recompletion'), 'recompletion_qr'],
-                    (object)[array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
+                        [get_string('recompletion', 'local_recompletion'), 'recompletion_qr'],
+                        (object) [array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
             }
 
             $records = $DB->get_records('local_recompletion_cha', $params);
             foreach ($records as $record) {
-                $context = \context_course::instance($record->course);
+                $context = context_course::instance($record->course);
                 writer::with_context($context)->export_data(
-                    [get_string('recompletion', 'local_recompletion'), 'recompletion_cha'],
-                    (object)[array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
+                        [get_string('recompletion', 'local_recompletion'), 'recompletion_cha'],
+                        (object) [array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
             }
 
-            $records = $DB->get_records('local_recompletion_hvp', array('user_id' => $userid, 'course' => $context->instanceid));
+            $records = $DB->get_records('local_recompletion_hvp', ['user_id' => $userid, 'course' => $context->instanceid]);
             foreach ($records as $record) {
-                $context = \context_course::instance($record->course);
+                $context = context_course::instance($record->course);
                 writer::with_context($context)->export_data(
-                    [get_string('recompletion', 'local_recompletion'), 'recompletion_hvp'],
-                    (object)[array_map([self::class, 'transform_db_row_to_session_data'], $record)]);
+                        [get_string('recompletion', 'local_recompletion'), 'recompletion_hvp'],
+                        (object) [array_map([self::class, 'transform_db_row_to_session_data'], $record)]);
             }
 
             $sql = "SELECT har.id,
@@ -331,66 +339,66 @@ class provider implements
 
             $records = $DB->get_records($sql, $params);
             foreach ($records as $record) {
-                $context = \context_course::instance($record->course);
+                $context = context_course::instance($record->course);
                 writer::with_context($context)->export_data(
-                    [get_string('recompletion', 'local_recompletion'), 'recompletion_h5pr'],
-                    (object)[array_map([self::class, 'transform_db_row_to_session_data'], $record)]);
+                        [get_string('recompletion', 'local_recompletion'), 'recompletion_h5pr'],
+                        (object) [array_map([self::class, 'transform_db_row_to_session_data'], $record)]);
             }
 
             $records = $DB->get_records('local_recompletion_la', $params);
             foreach ($records as $record) {
-                $context = \context_course::instance($record->course);
+                $context = context_course::instance($record->course);
                 writer::with_context($context)->export_data(
-                    [get_string('recompletion', 'local_recompletion'), 'lesson_attempts'],
-                    (object)[array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
+                        [get_string('recompletion', 'local_recompletion'), 'lesson_attempts'],
+                        (object) [array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
             }
 
             $records = $DB->get_records('local_recompletion_lg', $params);
             foreach ($records as $record) {
-                $context = \context_course::instance($record->course);
+                $context = context_course::instance($record->course);
                 writer::with_context($context)->export_data(
-                    [get_string('recompletion', 'local_recompletion'), 'lesson_grades'],
-                    (object)[array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
+                        [get_string('recompletion', 'local_recompletion'), 'lesson_grades'],
+                        (object) [array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
             }
 
             $records = $DB->get_records('local_recompletion_lt', $params);
             foreach ($records as $record) {
-                $context = \context_course::instance($record->course);
+                $context = context_course::instance($record->course);
                 writer::with_context($context)->export_data(
-                    [get_string('recompletion', 'local_recompletion'), 'lesson_timer'],
-                    (object)[array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
+                        [get_string('recompletion', 'local_recompletion'), 'lesson_timer'],
+                        (object) [array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
             }
 
             $records = $DB->get_records('local_recompletion_lb', $params);
             foreach ($records as $record) {
-                $context = \context_course::instance($record->course);
+                $context = context_course::instance($record->course);
                 writer::with_context($context)->export_data(
-                    [get_string('recompletion', 'local_recompletion'), 'lesson_branch'],
-                    (object)[array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
+                        [get_string('recompletion', 'local_recompletion'), 'lesson_branch'],
+                        (object) [array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
             }
 
             $records = $DB->get_records('local_recompletion_lo', $params);
             foreach ($records as $record) {
-                $context = \context_course::instance($record->course);
+                $context = context_course::instance($record->course);
                 writer::with_context($context)->export_data(
-                    [get_string('recompletion', 'local_recompletion'), 'lesson_overrides'],
-                    (object)[array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
+                        [get_string('recompletion', 'local_recompletion'), 'lesson_overrides'],
+                        (object) [array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
             }
 
             $records = $DB->get_records('local_recompletion_hpa', $params);
             foreach ($records as $record) {
-                $context = \context_course::instance($record->course);
+                $context = context_course::instance($record->course);
                 writer::with_context($context)->export_data(
-                    [get_string('recompletion', 'local_recompletion'), 'hotpot_attempts'],
-                    (object)[array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
+                        [get_string('recompletion', 'local_recompletion'), 'hotpot_attempts'],
+                        (object) [array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
             }
 
             $records = $DB->get_records('local_recompletion_cert', $params);
             foreach ($records as $record) {
-                $context = \context_course::instance($record->course);
+                $context = context_course::instance($record->course);
                 writer::with_context($context)->export_data(
-                    [get_string('recompletion', 'local_recompletion'), 'certificate_issues'],
-                    (object)[array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
+                        [get_string('recompletion', 'local_recompletion'), 'certificate_issues'],
+                        (object) [array_map([self::class, 'transform_db_row_to_session_data'], $records)]);
             }
         }
     }
@@ -404,9 +412,9 @@ class provider implements
      * @param stdClass $dbrow A row from the database containing session information.
      * @return stdClass The transformed row.
      */
-    private static function transform_db_row_to_session_data(stdClass $dbrow) : stdClass {
-        $times = array('timeenrolled', 'timestarted', 'timecompleted', 'timemodified', 'timemodifiedoffline',
-            'timestart', 'timefinish', 'timeseen', 'starttime', 'endtime', 'timecreated');
+    private static function transform_db_row_to_session_data(stdClass $dbrow): stdClass {
+        $times = ['timeenrolled', 'timestarted', 'timecompleted', 'timemodified', 'timemodifiedoffline',
+                'timestart', 'timefinish', 'timeseen', 'starttime', 'endtime', 'timecreated'];
         foreach ($times as $time) {
             if (isset($dbrow->$time) && (!empty($dbrow->$time))) {
                 $dbrow->$time = transform::datetime($dbrow->$time);
@@ -421,16 +429,16 @@ class provider implements
      *
      * @param context $context The specific context to delete data for.
      */
-    public static function delete_data_for_all_users_in_context(\context $context) {
+    public static function delete_data_for_all_users_in_context(context $context) {
         global $DB;
 
-        if (!$context instanceof \context_course) {
+        if (!$context instanceof context_course) {
             return;
         }
         $courseid = $context->instanceid;
 
-        $params = array('course' => $courseid);
-        $paramsid = array('courseid' => $courseid);
+        $params = ['course' => $courseid];
+        $paramsid = ['courseid' => $courseid];
         $DB->delete_records('local_recompletion_cc', $params);
         $DB->delete_records('local_recompletion_cc_cc', $params);
         $DB->delete_records('local_recompletion_cmc', $params);
@@ -460,13 +468,13 @@ class provider implements
      */
     public static function delete_data_for_user(approved_contextlist $contextlist) {
         global $DB;
-        $userid = (int)$contextlist->get_user()->id;
+        $userid = (int) $contextlist->get_user()->id;
         foreach ($contextlist as $context) {
-            if (!$context instanceof \context_course) {
+            if (!$context instanceof context_course) {
                 continue;
             }
             $courseid = $context->instanceid;
-            $params = array('userid' => $userid, 'course' => $courseid);
+            $params = ['userid' => $userid, 'course' => $courseid];
             $DB->delete_records('local_recompletion_cc', $params);
             $DB->delete_records('local_recompletion_cc_cc', $params);
             $DB->delete_records('local_recompletion_cmc', $params);
@@ -474,7 +482,7 @@ class provider implements
             $DB->delete_records('local_recompletion_qa', $params);
             $DB->delete_records('local_recompletion_qg', $params);
             $DB->delete_records_select('local_recompletion_ssv',
-                                       'attemptid in (SELECT id
+                    'attemptid in (SELECT id
                                                         FROM {local_recompletion_sa}
                                                        WHERE userid = :userid AND courseid = :course', $params);
             $DB->delete_records('local_recompletion_sa', $params);
@@ -499,10 +507,10 @@ class provider implements
      * @param int $userid The user to search.
      * @return contextlist $contextlist The contextlist containing the list of contexts used in this plugin.
      */
-    public static function get_contexts_for_userid(int $userid) : contextlist {
-        $contextlist = new \core_privacy\local\request\contextlist();
+    public static function get_contexts_for_userid(int $userid): contextlist {
+        $contextlist = new contextlist();
 
-        $params = array('contextlevel' => CONTEXT_COURSE, 'userid' => $userid);
+        $params = ['contextlevel' => CONTEXT_COURSE, 'userid' => $userid];
         $sql = "SELECT ctx.id
                   FROM {course} c
                   JOIN {context} ctx ON c.id = ctx.instanceid AND ctx.contextlevel = :contextlevel
@@ -598,18 +606,19 @@ class provider implements
 
         return $contextlist;
     }
+
     /**
      * Get the list of users who have data within a context.
      *
-     * @param   userlist    $userlist   The userlist containing the list of users who have data in this context/plugin combination.
+     * @param userlist $userlist The userlist containing the list of users who have data in this context/plugin combination.
      */
     public static function get_users_in_context(userlist $userlist) {
         $context = $userlist->get_context();
-        if (!$context instanceof \context_course) {
+        if (!$context instanceof context_course) {
             return;
         }
 
-        $params = array('contextlevel' => CONTEXT_COURSE, 'contextid' => $context->id);
+        $params = ['contextlevel' => CONTEXT_COURSE, 'contextid' => $context->id];
         $sql = "SELECT rc.userid
                   FROM {local_recompletion_cc} rc
                   JOIN {course} c ON rc.course = c.id
@@ -729,20 +738,21 @@ class provider implements
                   WHERE ctx.id = :contextid";
         $userlist->add_from_sql('userid', $sql, $params);
     }
+
     /**
      * Delete multiple users within a single context.
      *
-     * @param   approved_userlist       $userlist The approved context and user information to delete information for.
+     * @param approved_userlist $userlist The approved context and user information to delete information for.
      */
     public static function delete_data_for_users(approved_userlist $userlist) {
         global $DB;
         $context = $userlist->get_context();
-        if (!$context instanceof \context_course) {
+        if (!$context instanceof context_course) {
             return;
         }
         // Prepare SQL to gather all completed IDs.
         $userids = $userlist->get_userids();
-        list($insql, $inparams) = $DB->get_in_or_equal($userids, SQL_PARAMS_NAMED);
+        [$insql, $inparams] = $DB->get_in_or_equal($userids, SQL_PARAMS_NAMED);
         $params = array_merge($inparams, ['contextlevel' => CONTEXT_COURSE, 'contextid' => $context->id]);
 
         // Should probably make this simpler using some helper functions... but for now...
@@ -809,7 +819,7 @@ class provider implements
                   WHERE rc.userid $insql";
         $DB->delete_records_select('local_recompletion_ltia', "id $sql", $inparams);
 
-                $sql = "SELECT rc.id
+        $sql = "SELECT rc.id
                   FROM {local_recompletion_qr} rc
                   JOIN {course} c ON rc.course = c.id
                   JOIN {context} ctx ON c.id = ctx.instanceid AND ctx.contextlevel = :contextlevel
@@ -891,12 +901,12 @@ class provider implements
      * @param int $courseid a course_id
      * @param int|null $userid a user id
      */
-    private static function delete_hp5_activity_records(int $courseid, int $userid = null): void {
+    private static function delete_hp5_activity_records(int $courseid, int $userid = 0): void {
         global $DB;
 
         $where = 'a.course = :course';
         $conditions = ['course' => $courseid];
-        if (!empty($user)) {
+        if (!empty($userid)) {
             $where .= ' AND a.userid = :userid';
             $conditions['userid'] = $userid;
         }

--- a/classes/recompletion_form.php
+++ b/classes/recompletion_form.php
@@ -56,35 +56,35 @@ class local_recompletion_recompletion_form extends moodleform {
         $instance = (object) ($this->_customdata['instance'] ?? []);
         $config = get_config('local_recompletion');
 
-        $context = \context_course::instance($course->id);
+        $context = context_course::instance($course->id);
 
         $editoroptions = [
-            'subdirs' => 0,
-            'maxbytes' => 0,
-            'maxfiles' => 0,
-            'changeformat' => 0,
-            'context' => $context,
-            'noclean' => 0,
-            'trusttext' => 0,
-            'cols' => '50',
-            'rows' => '8',
+                'subdirs' => 0,
+                'maxbytes' => 0,
+                'maxfiles' => 0,
+                'changeformat' => 0,
+                'context' => $context,
+                'noclean' => 0,
+                'trusttext' => 0,
+                'cols' => '50',
+                'rows' => '8',
         ];
 
         $mform->addElement('select', 'recompletiontype', get_string('recompletiontype', 'local_recompletion'), [
-            self::RECOMPLETION_TYPE_DISABLED => get_string('recompletiontype:disabled', 'local_recompletion'),
-            self::RECOMPLETION_TYPE_PERIOD => get_string('recompletiontype:period', 'local_recompletion'),
-            self::RECOMPLETION_TYPE_ONDEMAND => get_string('recompletiontype:ondemand', 'local_recompletion'),
-            self::RECOMPLETION_TYPE_SCHEDULE => get_string('recompletiontype:schedule', 'local_recompletion'),
+                self::RECOMPLETION_TYPE_DISABLED => get_string('recompletiontype:disabled', 'local_recompletion'),
+                self::RECOMPLETION_TYPE_PERIOD => get_string('recompletiontype:period', 'local_recompletion'),
+                self::RECOMPLETION_TYPE_ONDEMAND => get_string('recompletiontype:ondemand', 'local_recompletion'),
+                self::RECOMPLETION_TYPE_SCHEDULE => get_string('recompletiontype:schedule', 'local_recompletion'),
         ]);
         $mform->setDefault('recompletiontype', self::RECOMPLETION_TYPE_DISABLED);
         $mform->addHelpButton('recompletiontype', 'recompletiontype', 'local_recompletion');
 
         $mform->addElement('select', 'recompletionnotify', get_string('recompletionnotify', 'local_recompletion'), [
-            self::RECOMPLETION_NOTIFY_DISABLED => get_string('recompletiontype:disabled', 'local_recompletion'),
-            self::RECOMPLETION_NOTIFY_COMPLETED_USERS => get_string('recompletionnotify:completed', 'local_recompletion'),
-            self::RECOMPLETION_NOTIFY_ENROLLED_USERS => get_string('recompletionnotify:enrolled', 'local_recompletion'),
-            self::RECOMPLETION_NOTIFY_ACTIVE_ENROLLED_USERS =>
-                get_string('recompletionnotify:activeenrolled', 'local_recompletion'),
+                self::RECOMPLETION_NOTIFY_DISABLED => get_string('recompletiontype:disabled', 'local_recompletion'),
+                self::RECOMPLETION_NOTIFY_COMPLETED_USERS => get_string('recompletionnotify:completed', 'local_recompletion'),
+                self::RECOMPLETION_NOTIFY_ENROLLED_USERS => get_string('recompletionnotify:enrolled', 'local_recompletion'),
+                self::RECOMPLETION_NOTIFY_ACTIVE_ENROLLED_USERS =>
+                        get_string('recompletionnotify:activeenrolled', 'local_recompletion'),
         ]);
         $mform->setDefault('recompletionnotify', $config->recompletionnotify ?? '');
         $mform->addHelpButton('recompletionnotify', 'recompletionnotify', 'local_recompletion');
@@ -118,7 +118,7 @@ class local_recompletion_recompletion_form extends moodleform {
         if (!empty($nextresettime)) {
             $formatted = userdate($nextresettime, get_string('strftimedatetime', 'langconfig'));
             $mform->addElement('static', 'calculatedtime', '',
-                               get_string('recompletioncalculateddate', 'local_recompletion', $formatted));
+                    get_string('recompletioncalculateddate', 'local_recompletion', $formatted));
             $mform->hideIf('calculatedtime', 'recompletiontype', 'noteq', self::RECOMPLETION_TYPE_SCHEDULE);
         }
 
@@ -134,7 +134,7 @@ class local_recompletion_recompletion_form extends moodleform {
         $mform->setDefault('recompletionemailsubject', $config->recompletionemailsubject);
 
         $mform->addElement('editor', 'recompletionemailbody', get_string('recompletionemailbody', 'local_recompletion'),
-            $editoroptions);
+                $editoroptions);
         $mform->setDefault('recompletionemailbody', ['text' => $config->recompletionemailbody, 'format' => FORMAT_HTML]);
         $mform->addHelpButton('recompletionemailbody', 'recompletionemailbody', 'local_recompletion');
         $mform->disabledIf('recompletionemailbody', 'recompletiontype', 'eq', '');

--- a/classes/reportbuilder/datasource/archived_certificate_issues.php
+++ b/classes/reportbuilder/datasource/archived_certificate_issues.php
@@ -54,19 +54,19 @@ class archived_certificate_issues extends datasource {
         $courseentity = new course();
         $coursealias = $courseentity->get_table_alias('course');
         $this->add_entity($courseentity
-            ->add_join("JOIN {course} {$coursealias} ON {$coursealias}.id = {$tablealias}.course"));
+                ->add_join("JOIN {course} {$coursealias} ON {$coursealias}.id = {$tablealias}.course"));
 
         // Join the course category entity.
         $coursecatentity = new course_category();
-        $categoriesalias  = $coursecatentity->get_table_alias('course_categories');
+        $categoriesalias = $coursecatentity->get_table_alias('course_categories');
         $this->add_entity($coursecatentity
-            ->add_join("JOIN {course_categories} {$categoriesalias} ON {$categoriesalias}.id = {$coursealias}.category"));
+                ->add_join("JOIN {course_categories} {$categoriesalias} ON {$categoriesalias}.id = {$coursealias}.category"));
 
         // Join the user entity.
         $userentity = new user();
         $useralias = $userentity->get_table_alias('user');
         $this->add_entity($userentity
-            ->add_join("JOIN {user} {$useralias} ON {$useralias}.id = {$tablealias}.userid"));
+                ->add_join("JOIN {user} {$useralias} ON {$useralias}.id = {$tablealias}.userid"));
 
         $this->add_all_from_entities();
     }
@@ -78,12 +78,12 @@ class archived_certificate_issues extends datasource {
      */
     public function get_default_columns(): array {
         return [
-            'user:fullnamewithlink',
-            'course:coursefullnamewithlink',
-            'certificate_issues:certificate',
-            'certificate_issues:code',
-            'certificate_issues:issueddate',
-            'certificate_issues:printdate',
+                'user:fullnamewithlink',
+                'course:coursefullnamewithlink',
+                'certificate_issues:certificate',
+                'certificate_issues:code',
+                'certificate_issues:issueddate',
+                'certificate_issues:printdate',
         ];
     }
 
@@ -94,7 +94,7 @@ class archived_certificate_issues extends datasource {
      */
     public function get_default_filters(): array {
         return [
-            'course:courseselector',
+                'course:courseselector',
         ];
     }
 

--- a/classes/reportbuilder/datasource/archived_course_module_completions.php
+++ b/classes/reportbuilder/datasource/archived_course_module_completions.php
@@ -54,19 +54,19 @@ class archived_course_module_completions extends datasource {
         $courseentity = new course();
         $coursealias = $courseentity->get_table_alias('course');
         $this->add_entity($courseentity
-            ->add_join("JOIN {course} {$coursealias} ON {$coursealias}.id = {$completionsalias}.course"));
+                ->add_join("JOIN {course} {$coursealias} ON {$coursealias}.id = {$completionsalias}.course"));
 
         // Join the course category entity.
         $coursecatentity = new course_category();
-        $categoriesalias  = $coursecatentity->get_table_alias('course_categories');
+        $categoriesalias = $coursecatentity->get_table_alias('course_categories');
         $this->add_entity($coursecatentity
-            ->add_join("JOIN {course_categories} {$categoriesalias} ON {$categoriesalias}.id = {$coursealias}.category"));
+                ->add_join("JOIN {course_categories} {$categoriesalias} ON {$categoriesalias}.id = {$coursealias}.category"));
 
         // Join the user entity.
         $userentity = new user();
         $useralias = $userentity->get_table_alias('user');
         $this->add_entity($userentity
-            ->add_join("JOIN {user} {$useralias} ON {$useralias}.id = {$completionsalias}.userid"));
+                ->add_join("JOIN {user} {$useralias} ON {$useralias}.id = {$completionsalias}.userid"));
 
         $this->add_all_from_entities();
     }
@@ -78,10 +78,10 @@ class archived_course_module_completions extends datasource {
      */
     public function get_default_columns(): array {
         return [
-            'user:fullnamewithlink',
-            'course:coursefullnamewithlink',
-            'course_modules_completion:coursemodule',
-            'course_modules_completion:completionstate',
+                'user:fullnamewithlink',
+                'course:coursefullnamewithlink',
+                'course_modules_completion:coursemodule',
+                'course_modules_completion:completionstate',
         ];
     }
 
@@ -92,10 +92,11 @@ class archived_course_module_completions extends datasource {
      */
     public function get_default_filters(): array {
         return [
-            'course:courseselector',
-            'course_modules_completion:completionstate',
+                'course:courseselector',
+                'course_modules_completion:completionstate',
         ];
     }
+
     /**
      * Return the conditions that will be added to the report once is created
      *

--- a/classes/reportbuilder/datasource/archived_h5pactivities_atempts.php
+++ b/classes/reportbuilder/datasource/archived_h5pactivities_atempts.php
@@ -54,19 +54,19 @@ class archived_h5pactivities_atempts extends datasource {
         $courseentity = new course();
         $coursealias = $courseentity->get_table_alias('course');
         $this->add_entity($courseentity
-            ->add_join("JOIN {course} {$coursealias} ON {$coursealias}.id = {$attemptsalias}.course"));
+                ->add_join("JOIN {course} {$coursealias} ON {$coursealias}.id = {$attemptsalias}.course"));
 
         // Join the course category entity.
         $coursecatentity = new course_category();
-        $categoriesalias  = $coursecatentity->get_table_alias('course_categories');
+        $categoriesalias = $coursecatentity->get_table_alias('course_categories');
         $this->add_entity($coursecatentity
-            ->add_join("JOIN {course_categories} {$categoriesalias} ON {$categoriesalias}.id = {$coursealias}.category"));
+                ->add_join("JOIN {course_categories} {$categoriesalias} ON {$categoriesalias}.id = {$coursealias}.category"));
 
         // Join the user entity.
         $userentity = new user();
         $useralias = $userentity->get_table_alias('user');
         $this->add_entity($userentity
-            ->add_join("JOIN {user} {$useralias} ON {$useralias}.id = {$attemptsalias}.userid"));
+                ->add_join("JOIN {user} {$useralias} ON {$useralias}.id = {$attemptsalias}.userid"));
 
         $this->add_all_from_entities();
     }
@@ -78,16 +78,16 @@ class archived_h5pactivities_atempts extends datasource {
      */
     public function get_default_columns(): array {
         return [
-            'user:fullnamewithlink',
-            'course:coursefullnamewithlink',
-            'h5pactivity_attempts:h5pactivityid',
-            'h5pactivity_attempts:attempt',
-            'h5pactivity_attempts:rawscore',
-            'h5pactivity_attempts:duration',
-            'h5pactivity_attempts:completion',
-            'h5pactivity_attempts:success',
-            'h5pactivity_attempts:timecreated',
-            'h5pactivity_attempts:timemodified',
+                'user:fullnamewithlink',
+                'course:coursefullnamewithlink',
+                'h5pactivity_attempts:h5pactivityid',
+                'h5pactivity_attempts:attempt',
+                'h5pactivity_attempts:rawscore',
+                'h5pactivity_attempts:duration',
+                'h5pactivity_attempts:completion',
+                'h5pactivity_attempts:success',
+                'h5pactivity_attempts:timecreated',
+                'h5pactivity_attempts:timemodified',
         ];
     }
 
@@ -98,8 +98,8 @@ class archived_h5pactivities_atempts extends datasource {
      */
     public function get_default_filters(): array {
         return [
-            'course:courseselector',
-            'h5pactivity_attempts:success'
+                'course:courseselector',
+                'h5pactivity_attempts:success',
         ];
     }
 

--- a/classes/reportbuilder/datasource/archived_hotpot_atempts.php
+++ b/classes/reportbuilder/datasource/archived_hotpot_atempts.php
@@ -54,19 +54,19 @@ class archived_hotpot_atempts extends datasource {
         $courseentity = new course();
         $coursealias = $courseentity->get_table_alias('course');
         $this->add_entity($courseentity
-            ->add_join("JOIN {course} {$coursealias} ON {$coursealias}.id = {$attemptsalias}.course"));
+                ->add_join("JOIN {course} {$coursealias} ON {$coursealias}.id = {$attemptsalias}.course"));
 
         // Join the course category entity.
         $coursecatentity = new course_category();
-        $categoriesalias  = $coursecatentity->get_table_alias('course_categories');
+        $categoriesalias = $coursecatentity->get_table_alias('course_categories');
         $this->add_entity($coursecatentity
-            ->add_join("JOIN {course_categories} {$categoriesalias} ON {$categoriesalias}.id = {$coursealias}.category"));
+                ->add_join("JOIN {course_categories} {$categoriesalias} ON {$categoriesalias}.id = {$coursealias}.category"));
 
         // Join the user entity.
         $userentity = new user();
         $useralias = $userentity->get_table_alias('user');
         $this->add_entity($userentity
-            ->add_join("JOIN {user} {$useralias} ON {$useralias}.id = {$attemptsalias}.userid"));
+                ->add_join("JOIN {user} {$useralias} ON {$useralias}.id = {$attemptsalias}.userid"));
 
         $this->add_all_from_entities();
     }
@@ -78,13 +78,13 @@ class archived_hotpot_atempts extends datasource {
      */
     public function get_default_columns(): array {
         return [
-            'user:fullnamewithlink',
-            'course:coursefullnamewithlink',
-            'hotpot_attempts:hotpotid',
-            'hotpot_attempts:starttime',
-            'hotpot_attempts:endtime',
-            'hotpot_attempts:score',
-            'hotpot_attempts:status',
+                'user:fullnamewithlink',
+                'course:coursefullnamewithlink',
+                'hotpot_attempts:hotpotid',
+                'hotpot_attempts:starttime',
+                'hotpot_attempts:endtime',
+                'hotpot_attempts:score',
+                'hotpot_attempts:status',
         ];
     }
 
@@ -95,8 +95,8 @@ class archived_hotpot_atempts extends datasource {
      */
     public function get_default_filters(): array {
         return [
-            'course:courseselector',
-            'hotpot_attempts:status',
+                'course:courseselector',
+                'hotpot_attempts:status',
         ];
     }
 

--- a/classes/reportbuilder/datasource/archived_quiz_atempts.php
+++ b/classes/reportbuilder/datasource/archived_quiz_atempts.php
@@ -54,19 +54,19 @@ class archived_quiz_atempts extends datasource {
         $courseentity = new course();
         $coursealias = $courseentity->get_table_alias('course');
         $this->add_entity($courseentity
-            ->add_join("JOIN {course} {$coursealias} ON {$coursealias}.id = {$quizgradesalias}.course"));
+                ->add_join("JOIN {course} {$coursealias} ON {$coursealias}.id = {$quizgradesalias}.course"));
 
         // Join the course category entity.
         $coursecatentity = new course_category();
-        $categoriesalias  = $coursecatentity->get_table_alias('course_categories');
+        $categoriesalias = $coursecatentity->get_table_alias('course_categories');
         $this->add_entity($coursecatentity
-            ->add_join("JOIN {course_categories} {$categoriesalias} ON {$categoriesalias}.id = {$coursealias}.category"));
+                ->add_join("JOIN {course_categories} {$categoriesalias} ON {$categoriesalias}.id = {$coursealias}.category"));
 
         // Join the user entity.
         $userentity = new user();
         $useralias = $userentity->get_table_alias('user');
         $this->add_entity($userentity
-            ->add_join("JOIN {user} {$useralias} ON {$useralias}.id = {$quizgradesalias}.userid"));
+                ->add_join("JOIN {user} {$useralias} ON {$useralias}.id = {$quizgradesalias}.userid"));
 
         $this->add_all_from_entities();
     }
@@ -78,14 +78,14 @@ class archived_quiz_atempts extends datasource {
      */
     public function get_default_columns(): array {
         return [
-            'user:fullnamewithlink',
-            'course:coursefullnamewithlink',
-            'quiz_attempts:quiz',
-            'quiz_attempts:attempt',
-            'quiz_attempts:state',
-            'quiz_attempts:timestart',
-            'quiz_attempts:timefinish',
-            'quiz_attempts:sumgrades',
+                'user:fullnamewithlink',
+                'course:coursefullnamewithlink',
+                'quiz_attempts:quiz',
+                'quiz_attempts:attempt',
+                'quiz_attempts:state',
+                'quiz_attempts:timestart',
+                'quiz_attempts:timefinish',
+                'quiz_attempts:sumgrades',
         ];
     }
 
@@ -96,7 +96,7 @@ class archived_quiz_atempts extends datasource {
      */
     public function get_default_filters(): array {
         return [
-            'course:courseselector',
+                'course:courseselector',
         ];
     }
 

--- a/classes/reportbuilder/entities/certificate_issues.php
+++ b/classes/reportbuilder/entities/certificate_issues.php
@@ -33,13 +33,13 @@ use lang_string;
 class certificate_issues extends base {
 
     /**
-     * Database tables that this entity uses and their default aliases
+     * Database tables that this entity uses
      *
-     * @return string[] Array of $tablename => $alias
+     * @return string[]
      */
-    protected function get_default_table_aliases(): array {
+    protected function get_default_tables(): array {
         return [
-            'local_recompletion_cert' => 'rcert'
+            'local_recompletion_cert',
         ];
     }
 

--- a/classes/reportbuilder/entities/certificate_issues.php
+++ b/classes/reportbuilder/entities/certificate_issues.php
@@ -39,7 +39,7 @@ class certificate_issues extends base {
      */
     protected function get_default_tables(): array {
         return [
-            'local_recompletion_cert',
+                'local_recompletion_cert',
         ];
     }
 
@@ -55,7 +55,7 @@ class certificate_issues extends base {
     /**
      * Initialise.
      *
-     * @return \core_reportbuilder\local\entities\base
+     * @return base
      */
     public function initialise(): base {
         $columns = $this->get_all_columns();
@@ -76,63 +76,63 @@ class certificate_issues extends base {
 
         // Course module.
         $columns[] = (new column(
-            'certificate',
-            new lang_string('pluginname', 'certificate'),
-            $this->get_entity_name()
+                'certificate',
+                new lang_string('pluginname', 'certificate'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_fields("{$tablealias}.certificateid, {$tablealias}.course")
-            ->set_is_sortable(true)
-            ->add_callback(static function($value, $row): string {
-                global $PAGE;
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_fields("{$tablealias}.certificateid, {$tablealias}.course")
+                ->set_is_sortable(true)
+                ->add_callback(static function($value, $row): string {
+                    global $PAGE;
 
-                $renderer = new core_renderer($PAGE, RENDERER_TARGET_GENERAL);
-                $modinfo = get_fast_modinfo($row->course);
+                    $renderer = new core_renderer($PAGE, RENDERER_TARGET_GENERAL);
+                    $modinfo = get_fast_modinfo($row->course);
 
-                if (!empty($modinfo) && !empty($modinfo->get_instances_of('certificate')
-                        && !empty($modinfo->get_instances_of('certificate')[$row->certificateid]))) {
-                    $cm = $modinfo->get_instances_of('certificate')[$row->certificateid];
-                    $modulename = get_string('modulename', $cm->modname);
-                    $activityicon = $renderer->pix_icon('monologo', $modulename, $cm->modname, ['class' => 'icon']);
+                    if (!empty($modinfo) && !empty($modinfo->get_instances_of('certificate')
+                                    && !empty($modinfo->get_instances_of('certificate')[$row->certificateid]))) {
+                        $cm = $modinfo->get_instances_of('certificate')[$row->certificateid];
+                        $modulename = get_string('modulename', $cm->modname);
+                        $activityicon = $renderer->pix_icon('monologo', $modulename, $cm->modname, ['class' => 'icon']);
 
-                    return $activityicon . html_writer::link($cm->url, format_string($cm->name), []);
-                } else {
-                    return (string) $row->certificateid;
-                }
-            });
+                        return $activityicon . html_writer::link($cm->url, format_string($cm->name), []);
+                    } else {
+                        return (string) $row->certificateid;
+                    }
+                });
 
         $columns[] = (new column(
-            'code',
-            new lang_string('code', 'certificate'),
-            $this->get_entity_name()
+                'code',
+                new lang_string('code', 'certificate'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TEXT)
-            ->add_field("{$tablealias}.code")
-            ->set_is_sortable(true);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_TEXT)
+                ->add_field("{$tablealias}.code")
+                ->set_is_sortable(true);
 
         $columns[] = (new column(
-            'issueddate',
-            new lang_string('issueddate', 'certificate'),
-            $this->get_entity_name()
+                'issueddate',
+                new lang_string('issueddate', 'certificate'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TIMESTAMP)
-            ->add_field("{$tablealias}.timecreated")
-            ->set_is_sortable(true)
-            ->add_callback([format::class, 'userdate']);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_TIMESTAMP)
+                ->add_field("{$tablealias}.timecreated")
+                ->set_is_sortable(true)
+                ->add_callback([format::class, 'userdate']);
 
         $columns[] = (new column(
-            'printdate',
-            new lang_string('printdate', 'certificate'),
-            $this->get_entity_name()
+                'printdate',
+                new lang_string('printdate', 'certificate'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TIMESTAMP)
-            ->add_field("{$tablealias}.printdate")
-            ->set_is_sortable(true)
-            ->add_callback([format::class, 'userdate']);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_TIMESTAMP)
+                ->add_field("{$tablealias}.printdate")
+                ->set_is_sortable(true)
+                ->add_callback([format::class, 'userdate']);
 
         return $columns;
     }

--- a/classes/reportbuilder/entities/course_completions.php
+++ b/classes/reportbuilder/entities/course_completions.php
@@ -40,7 +40,7 @@ class course_completions extends base {
      */
     protected function get_default_tables(): array {
         return [
-            'local_recompletion_cc',
+                'local_recompletion_cc',
         ];
     }
 
@@ -56,7 +56,7 @@ class course_completions extends base {
     /**
      * Initialise.
      *
-     * @return \core_reportbuilder\local\entities\base
+     * @return base
      */
     public function initialise(): base {
         $columns = $this->get_all_columns();
@@ -82,69 +82,69 @@ class course_completions extends base {
 
         // Completed column.
         $columns[] = (new column(
-            'completed',
-            new lang_string('completed', 'completion'),
-            $this->get_entity_name()
+                'completed',
+                new lang_string('completed', 'completion'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_BOOLEAN)
-            ->add_field("CASE WHEN {$coursecompletion}.timecompleted > 0 THEN 1 ELSE 0 END", 'completed')
-            ->add_field("{$coursecompletion}.userid")
-            ->set_is_sortable(true)
-            ->add_callback(static function(bool $value, stdClass $row): string {
-                if (!$row->userid) {
-                    return '';
-                }
-                return format::boolean_as_text($value);
-            });
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_BOOLEAN)
+                ->add_field("CASE WHEN {$coursecompletion}.timecompleted > 0 THEN 1 ELSE 0 END", 'completed')
+                ->add_field("{$coursecompletion}.userid")
+                ->set_is_sortable(true)
+                ->add_callback(static function(bool $value, stdClass $row): string {
+                    if (!$row->userid) {
+                        return '';
+                    }
+                    return format::boolean_as_text($value);
+                });
 
         // Time enrolled.
         $columns[] = (new column(
-            'timeenrolled',
-            new lang_string('timeenrolled', 'enrol'),
-            $this->get_entity_name()
+                'timeenrolled',
+                new lang_string('timeenrolled', 'enrol'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TIMESTAMP)
-            ->add_field("{$coursecompletion}.timeenrolled")
-            ->set_is_sortable(true)
-            ->add_callback([format::class, 'userdate']);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_TIMESTAMP)
+                ->add_field("{$coursecompletion}.timeenrolled")
+                ->set_is_sortable(true)
+                ->add_callback([format::class, 'userdate']);
 
         // Time started.
         $columns[] = (new column(
-            'timestarted',
-            new lang_string('timestarted', 'enrol'),
-            $this->get_entity_name()
+                'timestarted',
+                new lang_string('timestarted', 'enrol'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TIMESTAMP)
-            ->add_field("{$coursecompletion}.timestarted")
-            ->set_is_sortable(true)
-            ->add_callback([format::class, 'userdate']);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_TIMESTAMP)
+                ->add_field("{$coursecompletion}.timestarted")
+                ->set_is_sortable(true)
+                ->add_callback([format::class, 'userdate']);
 
         // Time completed.
         $columns[] = (new column(
-            'timecompleted',
-            new lang_string('timecompleted', 'completion'),
-            $this->get_entity_name()
+                'timecompleted',
+                new lang_string('timecompleted', 'completion'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TIMESTAMP)
-            ->add_field("{$coursecompletion}.timecompleted")
-            ->set_is_sortable(true)
-            ->add_callback([format::class, 'userdate']);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_TIMESTAMP)
+                ->add_field("{$coursecompletion}.timecompleted")
+                ->set_is_sortable(true)
+                ->add_callback([format::class, 'userdate']);
 
         // Time reaggregated.
         $columns[] = (new column(
-            'reaggregate',
-            new lang_string('timereaggregated', 'enrol'),
-            $this->get_entity_name()
+                'reaggregate',
+                new lang_string('timereaggregated', 'enrol'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TIMESTAMP)
-            ->add_field("{$coursecompletion}.reaggregate")
-            ->set_is_sortable(true)
-            ->add_callback([format::class, 'userdate']);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_TIMESTAMP)
+                ->add_field("{$coursecompletion}.reaggregate")
+                ->set_is_sortable(true)
+                ->add_callback([format::class, 'userdate']);
 
         return $columns;
     }
@@ -159,21 +159,21 @@ class course_completions extends base {
 
         // Time completed filter.
         $filters[] = (new filter(
-            date::class,
-            'timecompleted',
-            new lang_string('timecompleted', 'completion'),
-            $this->get_entity_name(),
-            "{$coursecompletion}.timecompleted"
+                date::class,
+                'timecompleted',
+                new lang_string('timecompleted', 'completion'),
+                $this->get_entity_name(),
+                "{$coursecompletion}.timecompleted"
         ))
-            ->add_joins($this->get_joins())
-            ->set_limited_operators([
-                date::DATE_ANY,
-                date::DATE_NOT_EMPTY,
-                date::DATE_EMPTY,
-                date::DATE_RANGE,
-                date::DATE_LAST,
-                date::DATE_CURRENT,
-            ]);
+                ->add_joins($this->get_joins())
+                ->set_limited_operators([
+                        date::DATE_ANY,
+                        date::DATE_NOT_EMPTY,
+                        date::DATE_EMPTY,
+                        date::DATE_RANGE,
+                        date::DATE_LAST,
+                        date::DATE_CURRENT,
+                ]);
 
         return $filters;
     }

--- a/classes/reportbuilder/entities/course_completions.php
+++ b/classes/reportbuilder/entities/course_completions.php
@@ -34,13 +34,13 @@ use stdClass;
 class course_completions extends base {
 
     /**
-     * Database tables that this entity uses and their default aliases
+     * Database tables that this entity uses
      *
-     * @return string[] Array of $tablename => $alias
+     * @return string[]
      */
-    protected function get_default_table_aliases(): array {
+    protected function get_default_tables(): array {
         return [
-            'local_recompletion_cc' => 'cc'
+            'local_recompletion_cc',
         ];
     }
 

--- a/classes/reportbuilder/entities/course_modules_completion.php
+++ b/classes/reportbuilder/entities/course_modules_completion.php
@@ -36,13 +36,13 @@ use lang_string;
 class course_modules_completion extends base {
 
     /**
-     * Database tables that this entity uses and their default aliases
+     * Database tables that this entity uses
      *
-     * @return string[] Array of $tablename => $alias
+     * @return string[]
      */
-    protected function get_default_table_aliases(): array {
+    protected function get_default_tables(): array {
         return [
-            'local_recompletion_cmc' => 'cmc'
+            'local_recompletion_cmc',
         ];
     }
 

--- a/classes/reportbuilder/entities/course_modules_completion.php
+++ b/classes/reportbuilder/entities/course_modules_completion.php
@@ -42,7 +42,7 @@ class course_modules_completion extends base {
      */
     protected function get_default_tables(): array {
         return [
-            'local_recompletion_cmc',
+                'local_recompletion_cmc',
         ];
     }
 
@@ -58,7 +58,7 @@ class course_modules_completion extends base {
     /**
      * Initialise.
      *
-     * @return \core_reportbuilder\local\entities\base
+     * @return base
      */
     public function initialise(): base {
         $columns = $this->get_all_columns();
@@ -83,63 +83,63 @@ class course_modules_completion extends base {
 
         // Completion state.
         $columns[] = (new column(
-            'completionstate',
-            new lang_string('status', 'local_recompletion'),
-            $this->get_entity_name()
+                'completionstate',
+                new lang_string('status', 'local_recompletion'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_field("{$completion}.completionstate")
-            ->set_is_sortable(true)
-            ->add_callback(static function($completionstate): string {
-                $states = [
-                    0 => get_string('notcompleted', 'completion'),
-                    1 => get_string('completion-y', 'completion'),
-                    2 => get_string('completion-pass', 'completion'),
-                    3 => get_string('completion-fail', 'completion'),
-                ];
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_field("{$completion}.completionstate")
+                ->set_is_sortable(true)
+                ->add_callback(static function($completionstate): string {
+                    $states = [
+                            0 => get_string('notcompleted', 'completion'),
+                            1 => get_string('completion-y', 'completion'),
+                            2 => get_string('completion-pass', 'completion'),
+                            3 => get_string('completion-fail', 'completion'),
+                    ];
 
-                return $states[$completionstate] ?? $completionstate;
-            });
+                    return $states[$completionstate] ?? $completionstate;
+                });
 
         // Course module ID.
         $columns[] = (new column(
-            'coursemodule',
-            new lang_string('module', 'course'),
-            $this->get_entity_name()
+                'coursemodule',
+                new lang_string('module', 'course'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_fields("{$completion}.coursemoduleid, {$completion}.course")
-            ->set_is_sortable(true)
-            ->add_callback(static function($value, $row): string {
-                global $PAGE;
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_fields("{$completion}.coursemoduleid, {$completion}.course")
+                ->set_is_sortable(true)
+                ->add_callback(static function($value, $row): string {
+                    global $PAGE;
 
-                $renderer = new core_renderer($PAGE, RENDERER_TARGET_GENERAL);
-                $modinfo = get_fast_modinfo($row->course);
+                    $renderer = new core_renderer($PAGE, RENDERER_TARGET_GENERAL);
+                    $modinfo = get_fast_modinfo($row->course);
 
-                if (!empty($modinfo) && !empty($modinfo->get_cms()[$row->coursemoduleid])) {
-                    $cm = $modinfo->get_cms()[$row->coursemoduleid];
-                    $modulename = get_string('modulename', $cm->modname);
-                    $activityicon = $renderer->pix_icon('monologo', $modulename, $cm->modname, ['class' => 'icon']);
+                    if (!empty($modinfo) && !empty($modinfo->get_cms()[$row->coursemoduleid])) {
+                        $cm = $modinfo->get_cms()[$row->coursemoduleid];
+                        $modulename = get_string('modulename', $cm->modname);
+                        $activityicon = $renderer->pix_icon('monologo', $modulename, $cm->modname, ['class' => 'icon']);
 
-                    return $activityicon . html_writer::link($cm->url, format_string($cm->name), []);
-                } else {
-                    return (string) $row->coursemoduleid;
-                }
-            });
+                        return $activityicon . html_writer::link($cm->url, format_string($cm->name), []);
+                    } else {
+                        return (string) $row->coursemoduleid;
+                    }
+                });
 
         // Time started.
         $columns[] = (new column(
-            'timemodified',
-            new lang_string('timemodified', 'local_recompletion'),
-            $this->get_entity_name()
+                'timemodified',
+                new lang_string('timemodified', 'local_recompletion'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TIMESTAMP)
-            ->add_field("{$completion}.timemodified")
-            ->set_is_sortable(true)
-            ->add_callback([format::class, 'userdate']);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_TIMESTAMP)
+                ->add_field("{$completion}.timemodified")
+                ->set_is_sortable(true)
+                ->add_callback([format::class, 'userdate']);
 
         return $columns;
     }
@@ -154,29 +154,29 @@ class course_modules_completion extends base {
 
         // Time completed filter.
         $filters[] = (new filter(
-            select::class,
-            'completionstate',
-            new lang_string('status', 'local_recompletion'),
-            $this->get_entity_name(),
-            "{$coursecompletion}.completionstate"
+                select::class,
+                'completionstate',
+                new lang_string('status', 'local_recompletion'),
+                $this->get_entity_name(),
+                "{$coursecompletion}.completionstate"
         ))
-            ->add_joins($this->get_joins())
-            ->set_options([
-                0 => get_string('notcompleted', 'completion'),
-                1 => get_string('completion-y', 'completion'),
-                2 => get_string('completion-pass', 'completion'),
-                3 => get_string('completion-fail', 'completion'),
-            ]);
+                ->add_joins($this->get_joins())
+                ->set_options([
+                        0 => get_string('notcompleted', 'completion'),
+                        1 => get_string('completion-y', 'completion'),
+                        2 => get_string('completion-pass', 'completion'),
+                        3 => get_string('completion-fail', 'completion'),
+                ]);
 
         // Custom course selector filter.
         $filters[] = (new filter(
-            course_selector::class,
-            'courseselector',
-            new lang_string('courseselect', 'core_reportbuilder'),
-            $this->get_entity_name(),
-            "{$coursecompletion}.course"
+                course_selector::class,
+                'courseselector',
+                new lang_string('courseselect', 'core_reportbuilder'),
+                $this->get_entity_name(),
+                "{$coursecompletion}.course"
         ))
-            ->add_joins($this->get_joins());
+                ->add_joins($this->get_joins());
 
         return $filters;
     }

--- a/classes/reportbuilder/entities/customcert_issues.php
+++ b/classes/reportbuilder/entities/customcert_issues.php
@@ -33,13 +33,13 @@ use lang_string;
 class customcert_issues extends base {
 
     /**
-     * Database tables that this entity uses and their default aliases
+     * Database tables that this entity uses
      *
-     * @return string[] Array of $tablename => $alias
+     * @return string[]
      */
-    protected function get_default_table_aliases(): array {
+    protected function get_default_tables(): array {
         return [
-            'local_recompletion_ccert_is' => 'ccert'
+            'local_recompletion_ccert_is',
         ];
     }
 

--- a/classes/reportbuilder/entities/customcert_issues.php
+++ b/classes/reportbuilder/entities/customcert_issues.php
@@ -39,7 +39,7 @@ class customcert_issues extends base {
      */
     protected function get_default_tables(): array {
         return [
-            'local_recompletion_ccert_is',
+                'local_recompletion_ccert_is',
         ];
     }
 
@@ -55,7 +55,7 @@ class customcert_issues extends base {
     /**
      * Initialise.
      *
-     * @return \core_reportbuilder\local\entities\base
+     * @return base
      */
     public function initialise(): base {
         $columns = $this->get_all_columns();
@@ -76,52 +76,52 @@ class customcert_issues extends base {
 
         // Course module.
         $columns[] = (new column(
-            'certificate',
-            new lang_string('pluginname', 'customcert'),
-            $this->get_entity_name()
+                'certificate',
+                new lang_string('pluginname', 'customcert'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_fields("{$tablealias}.customcertid, {$tablealias}.course")
-            ->set_is_sortable(true)
-            ->add_callback(static function($value, $row): string {
-                global $PAGE;
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_fields("{$tablealias}.customcertid, {$tablealias}.course")
+                ->set_is_sortable(true)
+                ->add_callback(static function($value, $row): string {
+                    global $PAGE;
 
-                $renderer = new core_renderer($PAGE, RENDERER_TARGET_GENERAL);
-                $modinfo = get_fast_modinfo($row->course);
+                    $renderer = new core_renderer($PAGE, RENDERER_TARGET_GENERAL);
+                    $modinfo = get_fast_modinfo($row->course);
 
-                if (!empty($modinfo) && !empty($modinfo->get_instances_of('customcert')
-                        && !empty($modinfo->get_instances_of('customcert')[$row->customcertid]))) {
-                    $cm = $modinfo->get_instances_of('customcert')[$row->customcertid];
-                    $modulename = get_string('modulename', $cm->modname);
-                    $activityicon = $renderer->pix_icon('monologo', $modulename, $cm->modname, ['class' => 'icon']);
+                    if (!empty($modinfo) && !empty($modinfo->get_instances_of('customcert')
+                                    && !empty($modinfo->get_instances_of('customcert')[$row->customcertid]))) {
+                        $cm = $modinfo->get_instances_of('customcert')[$row->customcertid];
+                        $modulename = get_string('modulename', $cm->modname);
+                        $activityicon = $renderer->pix_icon('monologo', $modulename, $cm->modname, ['class' => 'icon']);
 
-                    return $activityicon . html_writer::link($cm->url, format_string($cm->name), []);
-                } else {
-                    return (string) $row->customcertid;
-                }
-            });
+                        return $activityicon . html_writer::link($cm->url, format_string($cm->name), []);
+                    } else {
+                        return (string) $row->customcertid;
+                    }
+                });
 
         $columns[] = (new column(
-            'code',
-            new lang_string('code', 'customcert'),
-            $this->get_entity_name()
+                'code',
+                new lang_string('code', 'customcert'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TEXT)
-            ->add_field("{$tablealias}.code")
-            ->set_is_sortable(true);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_TEXT)
+                ->add_field("{$tablealias}.code")
+                ->set_is_sortable(true);
 
         $columns[] = (new column(
-            'issueddate',
-            new lang_string('receiveddate', 'customcert'),
-            $this->get_entity_name()
+                'issueddate',
+                new lang_string('receiveddate', 'customcert'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TIMESTAMP)
-            ->add_field("{$tablealias}.timecreated")
-            ->set_is_sortable(true)
-            ->add_callback([format::class, 'userdate']);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_TIMESTAMP)
+                ->add_field("{$tablealias}.timecreated")
+                ->set_is_sortable(true)
+                ->add_callback([format::class, 'userdate']);
 
         return $columns;
     }

--- a/classes/reportbuilder/entities/h5pactivity_attempts.php
+++ b/classes/reportbuilder/entities/h5pactivity_attempts.php
@@ -33,15 +33,15 @@ use lang_string;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class h5pactivity_attempts extends base {
-
+    
     /**
-     * Database tables that this entity uses and their default aliases
+     * Database tables that this entity uses
      *
-     * @return string[] Array of $tablename => $alias
+     * @return string[]
      */
-    protected function get_default_table_aliases(): array {
+    protected function get_default_tables(): array {
         return [
-            'local_recompletion_h5p' => 'h5p'
+            'local_recompletion_h5p',
         ];
     }
 

--- a/classes/reportbuilder/entities/h5pactivity_attempts.php
+++ b/classes/reportbuilder/entities/h5pactivity_attempts.php
@@ -33,7 +33,6 @@ use lang_string;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class h5pactivity_attempts extends base {
-    
     /**
      * Database tables that this entity uses
      *
@@ -41,7 +40,7 @@ class h5pactivity_attempts extends base {
      */
     protected function get_default_tables(): array {
         return [
-            'local_recompletion_h5p',
+                'local_recompletion_h5p',
         ];
     }
 
@@ -57,7 +56,7 @@ class h5pactivity_attempts extends base {
     /**
      * Initialise.
      *
-     * @return \core_reportbuilder\local\entities\base
+     * @return base
      */
     public function initialise(): base {
         $columns = $this->get_all_columns();
@@ -81,122 +80,122 @@ class h5pactivity_attempts extends base {
         $alias = $this->get_table_alias('local_recompletion_h5p');
 
         $columns[] = (new column(
-            'h5pactivityid',
-            new lang_string('pluginname', 'h5pactivity'),
-            $this->get_entity_name()
+                'h5pactivityid',
+                new lang_string('pluginname', 'h5pactivity'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_fields("{$alias}.h5pactivityid, {$alias}.course")
-            ->set_is_sortable(true)
-            ->add_callback(static function($value, $row): string {
-                global $PAGE;
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_fields("{$alias}.h5pactivityid, {$alias}.course")
+                ->set_is_sortable(true)
+                ->add_callback(static function($value, $row): string {
+                    global $PAGE;
 
-                $renderer = new core_renderer($PAGE, RENDERER_TARGET_GENERAL);
-                $modinfo = get_fast_modinfo($row->course);
+                    $renderer = new core_renderer($PAGE, RENDERER_TARGET_GENERAL);
+                    $modinfo = get_fast_modinfo($row->course);
 
-                if (!empty($modinfo) && !empty($modinfo->get_instances_of('h5pactivity')
-                        && !empty($modinfo->get_instances_of('h5pactivity')[$row->h5pactivityid]))) {
-                    $cm = $modinfo->get_instances_of('h5pactivity')[$row->h5pactivityid];
-                    $modulename = get_string('modulename', $cm->modname);
-                    $activityicon = $renderer->pix_icon('monologo', $modulename, $cm->modname, ['class' => 'icon']);
+                    if (!empty($modinfo) && !empty($modinfo->get_instances_of('h5pactivity')
+                                    && !empty($modinfo->get_instances_of('h5pactivity')[$row->h5pactivityid]))) {
+                        $cm = $modinfo->get_instances_of('h5pactivity')[$row->h5pactivityid];
+                        $modulename = get_string('modulename', $cm->modname);
+                        $activityicon = $renderer->pix_icon('monologo', $modulename, $cm->modname, ['class' => 'icon']);
 
-                    return $activityicon . html_writer::link($cm->url, format_string($cm->name), []);
-                } else {
-                    return (string) $row->h5pactivityid;
-                }
-            });
+                        return $activityicon . html_writer::link($cm->url, format_string($cm->name), []);
+                    } else {
+                        return (string) $row->h5pactivityid;
+                    }
+                });
 
         $columns[] = (new column(
-            'attempt',
-            new lang_string('attempt', 'h5pactivity'),
-            $this->get_entity_name()
+                'attempt',
+                new lang_string('attempt', 'h5pactivity'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_field("{$alias}.attempt")
-            ->set_is_sortable(true);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_field("{$alias}.attempt")
+                ->set_is_sortable(true);
 
         $columns[] = (new column(
-            'rawscore',
-            new lang_string('score', 'h5pactivity'),
-            $this->get_entity_name()
+                'rawscore',
+                new lang_string('score', 'h5pactivity'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_field("{$alias}.rawscore")
-            ->set_is_sortable(true);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_field("{$alias}.rawscore")
+                ->set_is_sortable(true);
 
         $columns[] = (new column(
-            'maxscore',
-            new lang_string('maxscore', 'h5pactivity'),
-            $this->get_entity_name()
+                'maxscore',
+                new lang_string('maxscore', 'h5pactivity'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_field("{$alias}.maxscore")
-            ->set_is_sortable(true);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_field("{$alias}.maxscore")
+                ->set_is_sortable(true);
 
         $columns[] = (new column(
-            'duration',
-            new lang_string('duration', 'h5pactivity'),
-            $this->get_entity_name()
+                'duration',
+                new lang_string('duration', 'h5pactivity'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_field("{$alias}.duration")
-            ->set_is_sortable(true);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_field("{$alias}.duration")
+                ->set_is_sortable(true);
 
         $columns[] = (new column(
-            'completion',
-            new lang_string('completion', 'h5pactivity'),
-            $this->get_entity_name()
+                'completion',
+                new lang_string('completion', 'h5pactivity'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_field("{$alias}.completion")
-            ->set_is_sortable(true);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_field("{$alias}.completion")
+                ->set_is_sortable(true);
 
         $columns[] = (new column(
-            'success',
-            new lang_string('outcome', 'h5pactivity'),
-            $this->get_entity_name()
+                'success',
+                new lang_string('outcome', 'h5pactivity'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_field("{$alias}.success")
-            ->set_is_sortable(true)
-            ->add_callback(static function($success): string {
-                if ($success === null) {
-                    return get_string('attempt_success_unknown', 'mod_h5pactivity');
-                } else if ($success) {
-                    return get_string('attempt_success_pass', 'mod_h5pactivity');
-                } else {
-                    return get_string('attempt_success_fail', 'mod_h5pactivity');
-                }
-            });
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_field("{$alias}.success")
+                ->set_is_sortable(true)
+                ->add_callback(static function($success): string {
+                    if ($success === null) {
+                        return get_string('attempt_success_unknown', 'mod_h5pactivity');
+                    } else if ($success) {
+                        return get_string('attempt_success_pass', 'mod_h5pactivity');
+                    } else {
+                        return get_string('attempt_success_fail', 'mod_h5pactivity');
+                    }
+                });
 
         $columns[] = (new column(
-            'timecreated',
-            new lang_string('timecreated', 'local_recompletion'),
-            $this->get_entity_name()
+                'timecreated',
+                new lang_string('timecreated', 'local_recompletion'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TIMESTAMP)
-            ->add_field("{$alias}.timecreated")
-            ->set_is_sortable(true)
-            ->add_callback([format::class, 'userdate']);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_TIMESTAMP)
+                ->add_field("{$alias}.timecreated")
+                ->set_is_sortable(true)
+                ->add_callback([format::class, 'userdate']);
 
         $columns[] = (new column(
-            'timemodified',
-            new lang_string('timemodified', 'local_recompletion'),
-            $this->get_entity_name()
+                'timemodified',
+                new lang_string('timemodified', 'local_recompletion'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TIMESTAMP)
-            ->add_field("{$alias}.timemodified")
-            ->set_is_sortable(true)
-            ->add_callback([format::class, 'userdate']);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_TIMESTAMP)
+                ->add_field("{$alias}.timemodified")
+                ->set_is_sortable(true)
+                ->add_callback([format::class, 'userdate']);
 
         return $columns;
     }
@@ -211,16 +210,16 @@ class h5pactivity_attempts extends base {
 
         // Time completed filter.
         $filters[] = (new filter(
-            select::class,
-            'success',
-            new lang_string('outcome', 'h5pactivity'),
-            $this->get_entity_name(),
-            "{$alias}.success"
+                select::class,
+                'success',
+                new lang_string('outcome', 'h5pactivity'),
+                $this->get_entity_name(),
+                "{$alias}.success"
         ))
-            ->add_joins($this->get_joins())
-            ->set_options([
-                0 => get_string('attempt_success_fail', 'mod_h5pactivity'),
-            ]);
+                ->add_joins($this->get_joins())
+                ->set_options([
+                        0 => get_string('attempt_success_fail', 'mod_h5pactivity'),
+                ]);
 
         return $filters;
     }

--- a/classes/reportbuilder/entities/hotpot_attempts.php
+++ b/classes/reportbuilder/entities/hotpot_attempts.php
@@ -33,7 +33,6 @@ use lang_string;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class hotpot_attempts extends base {
-    
     /**
      * Database tables that this entity uses
      *
@@ -41,7 +40,7 @@ class hotpot_attempts extends base {
      */
     protected function get_default_tables(): array {
         return [
-            'local_recompletion_hpa',
+                'local_recompletion_hpa',
         ];
     }
 
@@ -57,7 +56,7 @@ class hotpot_attempts extends base {
     /**
      * Initialise.
      *
-     * @return \core_reportbuilder\local\entities\base
+     * @return base
      */
     public function initialise(): base {
         $columns = $this->get_all_columns();
@@ -81,117 +80,117 @@ class hotpot_attempts extends base {
         $alias = $this->get_table_alias('local_recompletion_hpa');
 
         $columns[] = (new column(
-            'hotpotid',
-            new lang_string('pluginname', 'hotpot'),
-            $this->get_entity_name()
+                'hotpotid',
+                new lang_string('pluginname', 'hotpot'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_fields("{$alias}.hotpotid, {$alias}.course")
-            ->set_is_sortable(true)
-            ->add_callback(static function($value, $row): string {
-                global $PAGE;
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_fields("{$alias}.hotpotid, {$alias}.course")
+                ->set_is_sortable(true)
+                ->add_callback(static function($value, $row): string {
+                    global $PAGE;
 
-                $renderer = new core_renderer($PAGE, RENDERER_TARGET_GENERAL);
-                $modinfo = get_fast_modinfo($row->course);
+                    $renderer = new core_renderer($PAGE, RENDERER_TARGET_GENERAL);
+                    $modinfo = get_fast_modinfo($row->course);
 
-                if (!empty($modinfo) && !empty($modinfo->get_instances_of('hotpot')
-                        && !empty($modinfo->get_instances_of('hotpot')[$row->hotpotid]))) {
-                    $cm = $modinfo->get_instances_of('hotpot')[$row->hotpotid];
-                    $modulename = get_string('modulename', $cm->modname);
-                    $activityicon = $renderer->pix_icon('monologo', $modulename, $cm->modname, ['class' => 'icon']);
+                    if (!empty($modinfo) && !empty($modinfo->get_instances_of('hotpot')
+                                    && !empty($modinfo->get_instances_of('hotpot')[$row->hotpotid]))) {
+                        $cm = $modinfo->get_instances_of('hotpot')[$row->hotpotid];
+                        $modulename = get_string('modulename', $cm->modname);
+                        $activityicon = $renderer->pix_icon('monologo', $modulename, $cm->modname, ['class' => 'icon']);
 
-                    return $activityicon . html_writer::link($cm->url, format_string($cm->name), []);
-                } else {
-                    return (string) $row->hotpotid;
-                }
-            });
+                        return $activityicon . html_writer::link($cm->url, format_string($cm->name), []);
+                    } else {
+                        return (string) $row->hotpotid;
+                    }
+                });
 
         $columns[] = (new column(
-            'starttime',
-            new lang_string('starttime', 'local_recompletion'),
-            $this->get_entity_name()
+                'starttime',
+                new lang_string('starttime', 'local_recompletion'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TIMESTAMP)
-            ->add_field("{$alias}.starttime")
-            ->set_is_sortable(true)
-            ->add_callback([format::class, 'userdate']);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_TIMESTAMP)
+                ->add_field("{$alias}.starttime")
+                ->set_is_sortable(true)
+                ->add_callback([format::class, 'userdate']);
 
         $columns[] = (new column(
-            'endtime',
-            new lang_string('endtime', 'local_recompletion'),
-            $this->get_entity_name()
+                'endtime',
+                new lang_string('endtime', 'local_recompletion'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TIMESTAMP)
-            ->add_field("{$alias}.endtime")
-            ->set_is_sortable(true)
-            ->add_callback([format::class, 'userdate']);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_TIMESTAMP)
+                ->add_field("{$alias}.endtime")
+                ->set_is_sortable(true)
+                ->add_callback([format::class, 'userdate']);
 
         $columns[] = (new column(
-            'score',
-            new lang_string('score', 'local_recompletion'),
-            $this->get_entity_name()
+                'score',
+                new lang_string('score', 'local_recompletion'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_field("{$alias}.score")
-            ->set_is_sortable(true);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_field("{$alias}.score")
+                ->set_is_sortable(true);
 
         $columns[] = (new column(
-            'penalties',
-            new lang_string('penalties', 'local_recompletion'),
-            $this->get_entity_name()
+                'penalties',
+                new lang_string('penalties', 'local_recompletion'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_field("{$alias}.penalties")
-            ->set_is_sortable(true);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_field("{$alias}.penalties")
+                ->set_is_sortable(true);
 
         $columns[] = (new column(
-            'attempt',
-            new lang_string('attempt', 'h5pactivity'),
-            $this->get_entity_name()
+                'attempt',
+                new lang_string('attempt', 'h5pactivity'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_field("{$alias}.attempt")
-            ->set_is_sortable(true);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_field("{$alias}.attempt")
+                ->set_is_sortable(true);
 
         $columns[] = (new column(
-            'status',
-            new lang_string('status', 'local_recompletion'),
-            $this->get_entity_name()
+                'status',
+                new lang_string('status', 'local_recompletion'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_field("{$alias}.status")
-            ->set_is_sortable(true);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_field("{$alias}.status")
+                ->set_is_sortable(true);
 
         $columns[] = (new column(
-            'status',
-            new lang_string('status', 'local_recompletion'),
-            $this->get_entity_name()
+                'status',
+                new lang_string('status', 'local_recompletion'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_field("{$alias}.status")
-            ->set_is_sortable(true)
-            ->add_callback(static function($status): string {
-                switch ($status) {
-                    case 1:
-                        return get_string('inprogress', 'local_recompletion');
-                    case 2:
-                        return get_string('timedout', 'local_recompletion');
-                    case 3:
-                        return get_string('abandoned', 'local_recompletion');
-                    case 4:
-                        return get_string('completed', 'local_recompletion');
-                    default:
-                        return $status;
-                }
-            });
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_field("{$alias}.status")
+                ->set_is_sortable(true)
+                ->add_callback(static function($status): string {
+                    switch ($status) {
+                        case 1:
+                            return get_string('inprogress', 'local_recompletion');
+                        case 2:
+                            return get_string('timedout', 'local_recompletion');
+                        case 3:
+                            return get_string('abandoned', 'local_recompletion');
+                        case 4:
+                            return get_string('completed', 'local_recompletion');
+                        default:
+                            return $status;
+                    }
+                });
 
         return $columns;
     }
@@ -206,19 +205,19 @@ class hotpot_attempts extends base {
 
         // Time completed filter.
         $filters[] = (new filter(
-            select::class,
-            'status',
-            new lang_string('status', 'local_recompletion'),
-            $this->get_entity_name(),
-            "{$alias}.status"
+                select::class,
+                'status',
+                new lang_string('status', 'local_recompletion'),
+                $this->get_entity_name(),
+                "{$alias}.status"
         ))
-            ->add_joins($this->get_joins())
-            ->set_options([
-                1 => get_string('inprogress', 'local_recompletion'),
-                2 => get_string('timedout', 'local_recompletion'),
-                3 => get_string('abandoned', 'local_recompletion'),
-                4 => get_string('completed', 'local_recompletion')
-            ]);
+                ->add_joins($this->get_joins())
+                ->set_options([
+                        1 => get_string('inprogress', 'local_recompletion'),
+                        2 => get_string('timedout', 'local_recompletion'),
+                        3 => get_string('abandoned', 'local_recompletion'),
+                        4 => get_string('completed', 'local_recompletion'),
+                ]);
 
         return $filters;
     }

--- a/classes/reportbuilder/entities/hotpot_attempts.php
+++ b/classes/reportbuilder/entities/hotpot_attempts.php
@@ -33,15 +33,15 @@ use lang_string;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class hotpot_attempts extends base {
-
+    
     /**
-     * Database tables that this entity uses and their default aliases
+     * Database tables that this entity uses
      *
-     * @return string[] Array of $tablename => $alias
+     * @return string[]
      */
-    protected function get_default_table_aliases(): array {
+    protected function get_default_tables(): array {
         return [
-            'local_recompletion_hpa' => 'hpa'
+            'local_recompletion_hpa',
         ];
     }
 

--- a/classes/reportbuilder/entities/lesson_grades.php
+++ b/classes/reportbuilder/entities/lesson_grades.php
@@ -31,15 +31,15 @@ use lang_string;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class lesson_grades extends base {
-
+    
     /**
-     * Database tables that this entity uses and their default aliases
+     * Database tables that this entity uses
      *
-     * @return string[] Array of $tablename => $alias
+     * @return string[]
      */
-    protected function get_default_table_aliases(): array {
+    protected function get_default_tables(): array {
         return [
-            'local_recompletion_lg' => 'lg'
+            'local_recompletion_lg',
         ];
     }
 

--- a/classes/reportbuilder/entities/lesson_grades.php
+++ b/classes/reportbuilder/entities/lesson_grades.php
@@ -31,7 +31,7 @@ use lang_string;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class lesson_grades extends base {
-    
+
     /**
      * Database tables that this entity uses
      *
@@ -39,7 +39,7 @@ class lesson_grades extends base {
      */
     protected function get_default_tables(): array {
         return [
-            'local_recompletion_lg',
+                'local_recompletion_lg',
         ];
     }
 
@@ -55,7 +55,7 @@ class lesson_grades extends base {
     /**
      * Initialise.
      *
-     * @return \core_reportbuilder\local\entities\base
+     * @return base
      */
     public function initialise(): base {
         $columns = $this->get_all_columns();
@@ -76,54 +76,54 @@ class lesson_grades extends base {
 
         // Course module.
         $columns[] = (new column(
-            'lesson',
-            new lang_string('pluginname', 'lesson'),
-            $this->get_entity_name()
+                'lesson',
+                new lang_string('pluginname', 'lesson'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_fields("{$lessongrades}.lessonid, {$lessongrades}.course")
-            ->set_is_sortable(true)
-            ->add_callback(static function($value, $row): string {
-                global $PAGE;
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_fields("{$lessongrades}.lessonid, {$lessongrades}.course")
+                ->set_is_sortable(true)
+                ->add_callback(static function($value, $row): string {
+                    global $PAGE;
 
-                $renderer = new core_renderer($PAGE, RENDERER_TARGET_GENERAL);
-                $modinfo = get_fast_modinfo($row->course);
+                    $renderer = new core_renderer($PAGE, RENDERER_TARGET_GENERAL);
+                    $modinfo = get_fast_modinfo($row->course);
 
-                if (!empty($modinfo) && !empty($modinfo->get_instances_of('lesson')
-                        && !empty($modinfo->get_instances_of('lesson')[$row->lessonid]))) {
-                    $cm = $modinfo->get_instances_of('lesson')[$row->lessonid];
-                    $modulename = get_string('modulename', $cm->modname);
-                    $activityicon = $renderer->pix_icon('monologo', $modulename, $cm->modname, ['class' => 'icon']);
+                    if (!empty($modinfo) && !empty($modinfo->get_instances_of('lesson')
+                                    && !empty($modinfo->get_instances_of('lesson')[$row->lessonid]))) {
+                        $cm = $modinfo->get_instances_of('lesson')[$row->lessonid];
+                        $modulename = get_string('modulename', $cm->modname);
+                        $activityicon = $renderer->pix_icon('monologo', $modulename, $cm->modname, ['class' => 'icon']);
 
-                    return $activityicon . html_writer::link($cm->url, format_string($cm->name), []);
-                } else {
-                    return (string) $row->lessonid;
-                }
-            });
+                        return $activityicon . html_writer::link($cm->url, format_string($cm->name), []);
+                    } else {
+                        return (string) $row->lessonid;
+                    }
+                });
 
         // Grade.
         $columns[] = (new column(
-            'grade',
-            new lang_string('grade'),
-            $this->get_entity_name()
+                'grade',
+                new lang_string('grade'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_FLOAT)
-            ->add_field("{$lessongrades}.grade")
-            ->set_is_sortable(true);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_FLOAT)
+                ->add_field("{$lessongrades}.grade")
+                ->set_is_sortable(true);
 
         // Time completed.
         $columns[] = (new column(
-            'completed',
-            new lang_string('completed', 'lesson'),
-            $this->get_entity_name()
+                'completed',
+                new lang_string('completed', 'lesson'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TIMESTAMP)
-            ->add_field("{$lessongrades}.completed")
-            ->set_is_sortable(true)
-            ->add_callback([format::class, 'userdate']);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_TIMESTAMP)
+                ->add_field("{$lessongrades}.completed")
+                ->set_is_sortable(true)
+                ->add_callback([format::class, 'userdate']);
 
         return $columns;
     }

--- a/classes/reportbuilder/entities/quiz_attempts.php
+++ b/classes/reportbuilder/entities/quiz_attempts.php
@@ -31,7 +31,6 @@ use lang_string;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class quiz_attempts extends base {
-
     /**
      * Database tables that this entity uses
      *
@@ -39,7 +38,7 @@ class quiz_attempts extends base {
      */
     protected function get_default_tables(): array {
         return [
-            'local_recompletion_qa',
+                'local_recompletion_qa',
         ];
     }
 
@@ -55,7 +54,7 @@ class quiz_attempts extends base {
     /**
      * Initialise.
      *
-     * @return \core_reportbuilder\local\entities\base
+     * @return base
      */
     public function initialise(): base {
         $columns = $this->get_all_columns();
@@ -75,104 +74,104 @@ class quiz_attempts extends base {
         $alias = $this->get_table_alias('local_recompletion_qa');
 
         $columns[] = (new column(
-            'quiz',
-            new lang_string('pluginname', 'quiz'),
-            $this->get_entity_name()
+                'quiz',
+                new lang_string('pluginname', 'quiz'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_fields("{$alias}.quiz, {$alias}.course")
-            ->set_is_sortable(true)
-            ->add_callback(static function($value, $row): string {
-                global $PAGE;
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_fields("{$alias}.quiz, {$alias}.course")
+                ->set_is_sortable(true)
+                ->add_callback(static function($value, $row): string {
+                    global $PAGE;
 
-                $renderer = new core_renderer($PAGE, RENDERER_TARGET_GENERAL);
-                $modinfo = get_fast_modinfo($row->course);
+                    $renderer = new core_renderer($PAGE, RENDERER_TARGET_GENERAL);
+                    $modinfo = get_fast_modinfo($row->course);
 
-                if (!empty($modinfo) && !empty($modinfo->get_instances_of('quiz')
-                        && !empty($modinfo->get_instances_of('quiz')[$row->quiz]))) {
-                    $cm = $modinfo->get_instances_of('quiz')[$row->quiz];
-                    $modulename = get_string('modulename', $cm->modname);
-                    $activityicon = $renderer->pix_icon('monologo', $modulename, $cm->modname, ['class' => 'icon']);
+                    if (!empty($modinfo) && !empty($modinfo->get_instances_of('quiz')
+                                    && !empty($modinfo->get_instances_of('quiz')[$row->quiz]))) {
+                        $cm = $modinfo->get_instances_of('quiz')[$row->quiz];
+                        $modulename = get_string('modulename', $cm->modname);
+                        $activityicon = $renderer->pix_icon('monologo', $modulename, $cm->modname, ['class' => 'icon']);
 
-                    return $activityicon . html_writer::link($cm->url, format_string($cm->name), []);
-                } else {
-                    return (string) $row->quiz;
-                }
-            });
+                        return $activityicon . html_writer::link($cm->url, format_string($cm->name), []);
+                    } else {
+                        return (string) $row->quiz;
+                    }
+                });
 
         $columns[] = (new column(
-            'attempt',
-            new lang_string('attemptnumber', 'quiz'),
-            $this->get_entity_name()
+                'attempt',
+                new lang_string('attemptnumber', 'quiz'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_field("{$alias}.attempt")
-            ->set_is_sortable(true);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_field("{$alias}.attempt")
+                ->set_is_sortable(true);
 
         $columns[] = (new column(
-            'state',
-            new lang_string('attemptstate', 'quiz'),
-            $this->get_entity_name()
+                'state',
+                new lang_string('attemptstate', 'quiz'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TEXT)
-            ->add_field("{$alias}.state")
-            ->set_is_sortable(true)
-            ->add_callback(static function($state): string {
-                $states = [
-                    'inprogress' => get_string('stateinprogress', 'quiz'),
-                    'overdue' => get_string('stateoverdue', 'quiz'),
-                    'finished' => get_string('statefinished', 'quiz'),
-                    'abandoned' => get_string('stateabandoned', 'quiz'),
-                ];
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_TEXT)
+                ->add_field("{$alias}.state")
+                ->set_is_sortable(true)
+                ->add_callback(static function($state): string {
+                    $states = [
+                            'inprogress' => get_string('stateinprogress', 'quiz'),
+                            'overdue' => get_string('stateoverdue', 'quiz'),
+                            'finished' => get_string('statefinished', 'quiz'),
+                            'abandoned' => get_string('stateabandoned', 'quiz'),
+                    ];
 
-                return $states[$state] ?? $state;
-            });
-
-        $columns[] = (new column(
-            'timestart',
-            new lang_string('startedon', 'quiz'),
-            $this->get_entity_name()
-        ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TIMESTAMP)
-            ->add_field("{$alias}.timestart")
-            ->set_is_sortable(true)
-            ->add_callback([format::class, 'userdate']);
+                    return $states[$state] ?? $state;
+                });
 
         $columns[] = (new column(
-            'timefinish',
-            new lang_string('completedon', 'quiz'),
-            $this->get_entity_name()
+                'timestart',
+                new lang_string('startedon', 'quiz'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TIMESTAMP)
-            ->add_field("{$alias}.timefinish")
-            ->set_is_sortable(true)
-            ->add_callback([format::class, 'userdate']);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_TIMESTAMP)
+                ->add_field("{$alias}.timestart")
+                ->set_is_sortable(true)
+                ->add_callback([format::class, 'userdate']);
 
         $columns[] = (new column(
-            'sumgrades',
-            new lang_string('grade', 'quiz'),
-            $this->get_entity_name()
+                'timefinish',
+                new lang_string('completedon', 'quiz'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_field("{$alias}.sumgrades")
-            ->set_is_sortable(true);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_TIMESTAMP)
+                ->add_field("{$alias}.timefinish")
+                ->set_is_sortable(true)
+                ->add_callback([format::class, 'userdate']);
 
         $columns[] = (new column(
-            'timemodified',
-            new lang_string('timemodified', 'local_recompletion'),
-            $this->get_entity_name()
+                'sumgrades',
+                new lang_string('grade', 'quiz'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TIMESTAMP)
-            ->add_field("{$alias}.timemodified")
-            ->set_is_sortable(true)
-            ->add_callback([format::class, 'userdate']);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_field("{$alias}.sumgrades")
+                ->set_is_sortable(true);
+
+        $columns[] = (new column(
+                'timemodified',
+                new lang_string('timemodified', 'local_recompletion'),
+                $this->get_entity_name()
+        ))
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_TIMESTAMP)
+                ->add_field("{$alias}.timemodified")
+                ->set_is_sortable(true)
+                ->add_callback([format::class, 'userdate']);
 
         return $columns;
     }

--- a/classes/reportbuilder/entities/quiz_attempts.php
+++ b/classes/reportbuilder/entities/quiz_attempts.php
@@ -33,13 +33,13 @@ use lang_string;
 class quiz_attempts extends base {
 
     /**
-     * Database tables that this entity uses and their default aliases
+     * Database tables that this entity uses
      *
-     * @return string[] Array of $tablename => $alias
+     * @return string[]
      */
-    protected function get_default_table_aliases(): array {
+    protected function get_default_tables(): array {
         return [
-            'local_recompletion_qa' => 'qa'
+            'local_recompletion_qa',
         ];
     }
 

--- a/classes/reportbuilder/entities/quiz_grades.php
+++ b/classes/reportbuilder/entities/quiz_grades.php
@@ -33,13 +33,13 @@ use lang_string;
 class quiz_grades extends base {
 
     /**
-     * Database tables that this entity uses and their default aliases
+     * Database tables that this entity uses
      *
-     * @return string[] Array of $tablename => $alias
+     * @return string[]
      */
-    protected function get_default_table_aliases(): array {
+    protected function get_default_tables(): array {
         return [
-            'local_recompletion_qg' => 'qg'
+            'local_recompletion_qg',
         ];
     }
 

--- a/classes/reportbuilder/entities/quiz_grades.php
+++ b/classes/reportbuilder/entities/quiz_grades.php
@@ -39,7 +39,7 @@ class quiz_grades extends base {
      */
     protected function get_default_tables(): array {
         return [
-            'local_recompletion_qg',
+                'local_recompletion_qg',
         ];
     }
 
@@ -55,7 +55,7 @@ class quiz_grades extends base {
     /**
      * Initialise.
      *
-     * @return \core_reportbuilder\local\entities\base
+     * @return base
      */
     public function initialise(): base {
         $columns = $this->get_all_columns();
@@ -76,54 +76,54 @@ class quiz_grades extends base {
 
         // Course module.
         $columns[] = (new column(
-            'quiz',
-            new lang_string('pluginname', 'quiz'),
-            $this->get_entity_name()
+                'quiz',
+                new lang_string('pluginname', 'quiz'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_INTEGER)
-            ->add_fields("{$quizgrades}.quiz, {$quizgrades}.course")
-            ->set_is_sortable(true)
-            ->add_callback(static function($value, $row): string {
-                global $PAGE;
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_INTEGER)
+                ->add_fields("{$quizgrades}.quiz, {$quizgrades}.course")
+                ->set_is_sortable(true)
+                ->add_callback(static function($value, $row): string {
+                    global $PAGE;
 
-                $renderer = new core_renderer($PAGE, RENDERER_TARGET_GENERAL);
-                $modinfo = get_fast_modinfo($row->course);
+                    $renderer = new core_renderer($PAGE, RENDERER_TARGET_GENERAL);
+                    $modinfo = get_fast_modinfo($row->course);
 
-                if (!empty($modinfo) && !empty($modinfo->get_instances_of('quiz')
-                        && !empty($modinfo->get_instances_of('quiz')[$row->quiz]))) {
-                    $cm = $modinfo->get_instances_of('quiz')[$row->quiz];
-                    $modulename = get_string('modulename', $cm->modname);
-                    $activityicon = $renderer->pix_icon('monologo', $modulename, $cm->modname, ['class' => 'icon']);
+                    if (!empty($modinfo) && !empty($modinfo->get_instances_of('quiz')
+                                    && !empty($modinfo->get_instances_of('quiz')[$row->quiz]))) {
+                        $cm = $modinfo->get_instances_of('quiz')[$row->quiz];
+                        $modulename = get_string('modulename', $cm->modname);
+                        $activityicon = $renderer->pix_icon('monologo', $modulename, $cm->modname, ['class' => 'icon']);
 
-                    return $activityicon . html_writer::link($cm->url, format_string($cm->name), []);
-                } else {
-                    return (string) $row->quiz;
-                }
-            });
+                        return $activityicon . html_writer::link($cm->url, format_string($cm->name), []);
+                    } else {
+                        return (string) $row->quiz;
+                    }
+                });
 
         // Grade.
         $columns[] = (new column(
-            'grade',
-            new lang_string('grade'),
-            $this->get_entity_name()
+                'grade',
+                new lang_string('grade'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_FLOAT)
-            ->add_field("{$quizgrades}.grade")
-            ->set_is_sortable(true);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_FLOAT)
+                ->add_field("{$quizgrades}.grade")
+                ->set_is_sortable(true);
 
         // Time timemodified.
         $columns[] = (new column(
-            'timemodified',
-            new lang_string('timemodified', 'local_recompletion'),
-            $this->get_entity_name()
+                'timemodified',
+                new lang_string('timemodified', 'local_recompletion'),
+                $this->get_entity_name()
         ))
-            ->add_joins($this->get_joins())
-            ->set_type(column::TYPE_TIMESTAMP)
-            ->add_field("{$quizgrades}.timemodified")
-            ->set_is_sortable(true)
-            ->add_callback([format::class, 'userdate']);
+                ->add_joins($this->get_joins())
+                ->set_type(column::TYPE_TIMESTAMP)
+                ->add_field("{$quizgrades}.timemodified")
+                ->set_is_sortable(true)
+                ->add_callback([format::class, 'userdate']);
 
         return $columns;
     }

--- a/classes/table/participants.php
+++ b/classes/table/participants.php
@@ -24,8 +24,15 @@
 
 namespace local_recompletion\table;
 
+use completion_completion;
 use context;
+use core\output\checkbox_toggleall;
+use core_user\fields;
+use core_user\output\user_roles_editable;
 use DateTime;
+use moodle_url;
+use pix_icon;
+use stdClass;
 
 defined('MOODLE_INTERNAL') || die;
 
@@ -45,6 +52,7 @@ class participants extends \core_user\table\participants {
 
     /**
      * A list of roles that current user can view in a context.
+     *
      * @var array
      */
     protected $viewableroles;
@@ -69,13 +77,13 @@ class participants extends \core_user\table\participants {
 
         $bulkoperations = has_capability('local/recompletion:bulkoperations', $this->context);
         if ($bulkoperations) {
-            $mastercheckbox = new \core\output\checkbox_toggleall('participants-table', true, [
-                'id' => 'select-all-participants',
-                'name' => 'select-all-participants',
-                'label' => get_string('selectall'),
-                'labelclasses' => 'sr-only',
-                'classes' => 'm-1',
-                'checked' => false,
+            $mastercheckbox = new checkbox_toggleall('participants-table', true, [
+                    'id' => 'select-all-participants',
+                    'name' => 'select-all-participants',
+                    'label' => get_string('selectall'),
+                    'labelclasses' => 'sr-only',
+                    'classes' => 'm-1',
+                    'checked' => false,
             ]);
             $headers[] = $OUTPUT->render($mastercheckbox);
             $columns[] = 'select';
@@ -84,9 +92,9 @@ class participants extends \core_user\table\participants {
         $headers[] = get_string('fullname');
         $columns[] = 'fullname';
 
-        $extrafields = \core_user\fields::get_identity_fields($this->context);
+        $extrafields = fields::get_identity_fields($this->context);
         foreach ($extrafields as $field) {
-            $headers[] = \core_user\fields::get_display_name($field);
+            $headers[] = fields::get_display_name($field);
             $columns[] = $field;
         }
 
@@ -94,7 +102,7 @@ class participants extends \core_user\table\participants {
         $columns[] = 'roles';
 
         // Get the list of fields we have to hide.
-        $hiddenfields = array();
+        $hiddenfields = [];
         if (!has_capability('moodle/course:viewhiddenuserfields', $this->context)) {
             $hiddenfields = array_flip(explode(',', $CFG->hiddenuserfields));
         }
@@ -155,14 +163,14 @@ class participants extends \core_user\table\participants {
         $this->profileroles = get_profile_roles($this->context);
         $this->viewableroles = get_viewable_roles($this->context);
         $this->recompletionenabled = $DB->get_field('local_recompletion_config',
-            'value', array('course' => $this->course->id, 'name' => 'recompletiontype'));
+                'value', ['course' => $this->course->id, 'name' => 'recompletiontype']);
 
         if (!$this->columns) {
             $onerow = $DB->get_record_sql("SELECT {$this->sql->fields} FROM {$this->sql->from} WHERE {$this->sql->where}",
-                $this->sql->params, IGNORE_MULTIPLE);
+                    $this->sql->params, IGNORE_MULTIPLE);
             // If columns is not set then define columns as the keys of the rows returned from the db.
-            $this->define_columns(array_keys((array)$onerow));
-            $this->define_headers(array_keys((array)$onerow));
+            $this->define_columns(array_keys((array) $onerow));
+            $this->define_headers(array_keys((array) $onerow));
         }
         $this->pagesize = $pagesize;
         $this->setup();
@@ -172,52 +180,54 @@ class participants extends \core_user\table\participants {
         $this->finish_output();
 
     }
+
     /**
      * Generate the course completion column.
      *
-     * @param \stdClass $data
+     * @param stdClass $data
      * @return string
      */
     public function col_coursecompletion($data) {
         global $OUTPUT;
         // Load completion from cache.
-        $params = array(
-            'userid'    => $data->id,
-            'course'    => $this->course->id
-        );
+        $params = [
+                'userid' => $data->id,
+                'course' => $this->course->id,
+        ];
 
-        $ccompletion = new \completion_completion($params);
+        $ccompletion = new completion_completion($params);
         $value = '';
         if ($ccompletion->is_complete()) {
             $value = userdate($ccompletion->timecompleted, get_string('strftimedatetimeshort', 'langconfig'));
         }
-        $url = new \moodle_url('/local/recompletion/editcompletion.php', array('id' => $this->course->id, 'user' => $data->id));
-        $value .= $OUTPUT->action_link($url, '', null, null, new \pix_icon('t/edit', get_string('edit')));
+        $url = new moodle_url('/local/recompletion/editcompletion.php', ['id' => $this->course->id, 'user' => $data->id]);
+        $value .= $OUTPUT->action_link($url, '', null, null, new pix_icon('t/edit', get_string('edit')));
         if (!empty($this->recompletionenabled)) {
-            $url = new \moodle_url('/local/recompletion/resetcompletion.php',
-                array('id' => $this->course->id, 'user' => $data->id));
+            $url = new moodle_url('/local/recompletion/resetcompletion.php',
+                    ['id' => $this->course->id, 'user' => $data->id]);
             $value .= $OUTPUT->action_link($url, get_string('resetallcompletion', 'local_recompletion'));
         }
         return $value;
     }
+
     /**
      * User roles column.
      *
-     * @param \stdClass $data
+     * @param stdClass $data
      * @return string
      */
     public function col_roles($data) {
         global $OUTPUT;
 
         $roles = isset($this->allroleassignments[$data->id]) ? $this->allroleassignments[$data->id] : [];
-        $editable = new \core_user\output\user_roles_editable($this->course,
-            $this->context,
-            $data,
-            $this->allroles,
-            $this->assignableroles,
-            $this->profileroles,
-            $roles,
-            $this->viewableroles);
+        $editable = new user_roles_editable($this->course,
+                $this->context,
+                $data,
+                $this->allroles,
+                $this->assignableroles,
+                $this->profileroles,
+                $roles,
+                $this->viewableroles);
 
         return $OUTPUT->render_from_template('core/inplace_editable', $editable->export_for_template($OUTPUT));
     }

--- a/classes/task/check_recompletion.php
+++ b/classes/task/check_recompletion.php
@@ -25,6 +25,15 @@
 
 namespace local_recompletion\task;
 
+use cache;
+use completion_info;
+use context_course;
+use core\task\scheduled_task;
+use grade_grade;
+use grade_item;
+use local_recompletion\event\completion_reset;
+use stdClass;
+
 /**
  * Check for users that need to recomplete.
  *
@@ -33,7 +42,7 @@ namespace local_recompletion\task;
  * @copyright  2017 Dan Marsden
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class check_recompletion extends \core\task\scheduled_task {
+class check_recompletion extends scheduled_task {
     /**
      * Returns the name of this task.
      */
@@ -56,9 +65,9 @@ class check_recompletion extends \core\task\scheduled_task {
                   JOIN {local_recompletion_config} r3 ON r3.course = cc.course
                                                      AND r3.name = 'recompletiontype' AND r3.value = 'period'
                   JOIN {course} c ON c.id = cc.course
-                 WHERE c.enablecompletion = ".COMPLETION_ENABLED."
+                 WHERE c.enablecompletion = " . COMPLETION_ENABLED . "
                    AND cc.timecompleted > 0
-                   AND (cc.timecompleted + ".$DB->sql_cast_char2int('r2.value').") < ?";
+                   AND (cc.timecompleted + " . $DB->sql_cast_char2int('r2.value') . ") < ?";
         $users = $DB->get_records_sql($sql, [$now]);
 
         // Schedule based recompletion.
@@ -74,7 +83,7 @@ class check_recompletion extends \core\task\scheduled_task {
              LEFT JOIN {local_recompletion_config} r3 ON r3.course = cc.course AND r3.name = 'nextresettime'
                   JOIN {local_recompletion_config} r4 ON r4.course = cc.course AND r4.name = 'recompletionschedule'
                   JOIN {course} c ON c.id = cc.course
-                 WHERE c.enablecompletion = ".COMPLETION_ENABLED."
+                 WHERE c.enablecompletion = " . COMPLETION_ENABLED . "
                    AND cc.timecompleted > 0";
         $recompletions = $DB->get_records_sql($sql, [$now]);
         foreach ($recompletions as $record) {
@@ -94,7 +103,7 @@ class check_recompletion extends \core\task\scheduled_task {
         global $CFG, $DB;
         require_once($CFG->dirroot . '/local/recompletion/locallib.php');
 
-        if (!\completion_info::is_enabled_for_site()) {
+        if (!completion_info::is_enabled_for_site()) {
             return;
         }
 
@@ -122,10 +131,10 @@ class check_recompletion extends \core\task\scheduled_task {
             // If this course hasn't had its nextresettime set, add it to the array for after.
             if (!isset($updateresettimes[$course->id]) && isset($user->schedule)) {
                 // Update next reset time.
-                $newconfig = new \stdClass();
+                $newconfig = new stdClass();
                 if (isset($config->nextresettime)) {
                     $newconfig->id = $DB->get_field('local_recompletion_config', 'id',
-                        ['course' => $course->id, 'name' => 'nextresettime']);
+                            ['course' => $course->id, 'name' => 'nextresettime']);
                 }
                 $newconfig->course = $course->id;
                 $newconfig->name = 'nextresettime';
@@ -147,9 +156,10 @@ class check_recompletion extends \core\task\scheduled_task {
 
     /**
      * Reset and archive completion records
-     * @param \int $userid - user id
-     * @param \stdClass $course - course record.
-     * @param \stdClass $config - recompletion config.
+     *
+     * @param int $userid - user id
+     * @param stdClass $course - course record.
+     * @param stdClass $config - recompletion config.
      */
     protected function reset_completions($userid, $course, $config) {
         global $DB;
@@ -191,17 +201,18 @@ class check_recompletion extends \core\task\scheduled_task {
 
     /**
      * Notify user of recompletion.
-     * @param \int $userid - user id
-     * @param \stdclass $course - record from course table.
-     * @param \stdClass $config - recompletion config.
+     *
+     * @param int $userid - user id
+     * @param stdclass $course - record from course table.
+     * @param stdClass $config - recompletion config.
      */
     protected function notify_user($userid, $course, $config) {
         global $DB, $CFG;
 
         $userrecord = $DB->get_record('user', ['id' => $userid]);
-        $context = \context_course::instance($course->id);
+        $context = context_course::instance($course->id);
         $from = get_admin();
-        $a = new \stdClass();
+        $a = new stdClass();
         $a->coursename = format_string($course->fullname, true, ['context' => $context]);
         $a->profileurl = "$CFG->wwwroot/user/view.php?id=$userrecord->id&course=$course->id";
         $a->link = course_get_url($course)->out();
@@ -212,15 +223,15 @@ class check_recompletion extends \core\task\scheduled_task {
             $message = str_replace($key, $value, $message);
             // Message body stored as html - some might be non-html so we have to handle both, not clean but it works for now.
             $keyhtml = [
-                '{$a-&gt;coursename}',
-                '{$a-&gt;profileurl}',
-                '{$a-&gt;link}',
-                '{$a-&gt;fullname}',
-                '{$a-&gt;email}',
+                    '{$a-&gt;coursename}',
+                    '{$a-&gt;profileurl}',
+                    '{$a-&gt;link}',
+                    '{$a-&gt;fullname}',
+                    '{$a-&gt;email}',
             ];
             $message = str_replace($keyhtml, $value, $message);
             $messagehtml = format_text($message, FORMAT_HTML, ['context' => $context,
-                'para' => false, 'newlines' => true, 'filter' => true]);
+                    'para' => false, 'newlines' => true, 'filter' => true]);
             $messagetext = html_to_text($messagehtml);
         } else {
             $messagetext = get_string('recompletionemaildefaultbody', 'local_recompletion', $a);
@@ -240,9 +251,10 @@ class check_recompletion extends \core\task\scheduled_task {
 
     /**
      * Reset user completion.
-     * @param \int $userid - id of user.
-     * @param \stdClass $course - course record.
-     * @param \stdClass $config - recompletion config.
+     *
+     * @param int $userid - id of user.
+     * @param stdClass $course - course record.
+     * @param stdClass $config - recompletion config.
      */
     public function reset_user($userid, $course, $config = null) {
         global $CFG, $DB;
@@ -251,7 +263,7 @@ class check_recompletion extends \core\task\scheduled_task {
 
         if (empty($config)) {
             $config = (object) $DB->get_records_menu('local_recompletion_config',
-                                                     ['course' => $course->id], '', 'name, value');
+                    ['course' => $course->id], '', 'name, value');
         }
         if (empty($config->recompletiontype)) {
             $errors[] = get_string('recompletionnotenabledincourse', 'local_recompletion', $course->id);
@@ -281,9 +293,9 @@ class check_recompletion extends \core\task\scheduled_task {
 
         // Delete current grade information.
         if ($config->deletegradedata) {
-            if ($items = \grade_item::fetch_all(['courseid' => $course->id])) {
+            if ($items = grade_item::fetch_all(['courseid' => $course->id])) {
                 foreach ($items as $item) {
-                    if ($grades = \grade_grade::fetch_all(['userid' => $userid, 'itemid' => $item->id])) {
+                    if ($grades = grade_grade::fetch_all(['userid' => $userid, 'itemid' => $item->id])) {
                         foreach ($grades as $grade) {
                             $grade->delete('local_recompletion');
                         }
@@ -292,7 +304,7 @@ class check_recompletion extends \core\task\scheduled_task {
             }
         }
 
-        $context = \context_course::instance($course->id);
+        $context = context_course::instance($course->id);
 
         // Determine if user should be notified.
         if (!empty($config->recompletionnotify)) {
@@ -311,13 +323,13 @@ class check_recompletion extends \core\task\scheduled_task {
         }
 
         // Trigger completion reset event for this user.
-        $event = \local_recompletion\event\completion_reset::create(
-            [
-                'objectid'      => $course->id,
-                'relateduserid' => $userid,
-                'courseid' => $course->id,
-                'context' => $context,
-            ]
+        $event = completion_reset::create(
+                [
+                        'objectid' => $course->id,
+                        'relateduserid' => $userid,
+                        'courseid' => $course->id,
+                        'context' => $context,
+                ]
         );
         $event->trigger();
 
@@ -325,10 +337,10 @@ class check_recompletion extends \core\task\scheduled_task {
 
         if ($clearcache) {
             // Difficult to find affected users, just purge all completion cache.
-            \cache::make('core', 'completion')->purge();
+            cache::make('core', 'completion')->purge();
             // Clear coursecompletion cache which was added in Moodle 3.2.
             if ($CFG->version >= 2016120500) {
-                \cache::make('core', 'coursecompletion')->purge();
+                cache::make('core', 'coursecompletion')->purge();
             }
         }
         return $errors;

--- a/db/access.php
+++ b/db/access.php
@@ -26,34 +26,34 @@ defined('MOODLE_INTERNAL') || die();
 
 $capabilities = [
 
-    'local/recompletion:manage' => [
-        'riskbitmask' => RISK_XSS,
-        'captype' => 'write',
-        'contextlevel' => CONTEXT_COURSE,
-        'archetypes' => [
-            'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW,
-        ]
-    ],
-    'local/recompletion:resetmycompletion' => [
-        'riskbitmask' => RISK_XSS,
-        'captype' => 'write',
-        'contextlevel' => CONTEXT_COURSE,
-        'archetypes' => [
-            'student' => CAP_ALLOW,
-            'teacher' => CAP_ALLOW,
-            'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW,
-        ]
-    ],
-    'local/recompletion:bulkoperations' => [
-        'riskbitmask' => RISK_XSS,
-        'captype' => 'write',
-        'contextlevel' => CONTEXT_COURSE,
-        'archetypes' => [
-            'editingteacher' => CAP_ALLOW,
-            'manager' => CAP_ALLOW,
+        'local/recompletion:manage' => [
+                'riskbitmask' => RISK_XSS,
+                'captype' => 'write',
+                'contextlevel' => CONTEXT_COURSE,
+                'archetypes' => [
+                        'editingteacher' => CAP_ALLOW,
+                        'manager' => CAP_ALLOW,
+                ],
         ],
-        'clonepermissionsfrom' => 'moodle/course:bulkmessaging',
-    ],
+        'local/recompletion:resetmycompletion' => [
+                'riskbitmask' => RISK_XSS,
+                'captype' => 'write',
+                'contextlevel' => CONTEXT_COURSE,
+                'archetypes' => [
+                        'student' => CAP_ALLOW,
+                        'teacher' => CAP_ALLOW,
+                        'editingteacher' => CAP_ALLOW,
+                        'manager' => CAP_ALLOW,
+                ],
+        ],
+        'local/recompletion:bulkoperations' => [
+                'riskbitmask' => RISK_XSS,
+                'captype' => 'write',
+                'contextlevel' => CONTEXT_COURSE,
+                'archetypes' => [
+                        'editingteacher' => CAP_ALLOW,
+                        'manager' => CAP_ALLOW,
+                ],
+                'clonepermissionsfrom' => 'moodle/course:bulkmessaging',
+        ],
 ];

--- a/db/events.php
+++ b/db/events.php
@@ -25,17 +25,17 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$observers = array (
-    array(
-        'eventname' => '\mod_assign\event\submission_graded',
-        'callback' => '\local_recompletion\observer::submission_graded'
-    ),
-    array(
-        'eventname' => '\core\event\user_enrolment_deleted',
-        'callback' => '\local_recompletion\observer::user_enrolment_deleted'
-    ),
-    array(
-        'eventname' => '\core\event\course_created',
-        'callback' => '\local_recompletion\observer::course_created'
-    ),
-);
+$observers = [
+        [
+                'eventname' => '\mod_assign\event\submission_graded',
+                'callback' => '\local_recompletion\observer::submission_graded',
+        ],
+        [
+                'eventname' => '\core\event\user_enrolment_deleted',
+                'callback' => '\local_recompletion\observer::user_enrolment_deleted',
+        ],
+        [
+                'eventname' => '\core\event\course_created',
+                'callback' => '\local_recompletion\observer::course_created',
+        ],
+];

--- a/db/install.xml
+++ b/db/install.xml
@@ -1,523 +1,538 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <XMLDB PATH="local/recompletion/db" VERSION="20231121" COMMENT="XMLDB file for Moodle local/recompletion"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="../../../lib/xmldb/xmldb.xsd"
 >
-  <TABLES>
-    <TABLE NAME="local_recompletion_cc" COMMENT="archive of course_completions table">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="timeenrolled" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="timestarted" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="timecompleted" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="reaggregate" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="userid" UNIQUE="false" FIELDS="userid"/>
-        <INDEX NAME="course" UNIQUE="false" FIELDS="course"/>
-        <INDEX NAME="timecompleted" UNIQUE="false" FIELDS="timecompleted"/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="local_recompletion_cc_cc" COMMENT="archive of course_completion_crit_compl">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="criteriaid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Completion criteria this references"/>
-        <FIELD NAME="gradefinal" TYPE="number" LENGTH="10" NOTNULL="false" SEQUENCE="false" DECIMALS="5" COMMENT="The final grade for the course (included regardless of whether a passing grade was required)"/>
-        <FIELD NAME="unenroled" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Timestamp when the user was unenroled"/>
-        <FIELD NAME="timecompleted" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="userid" UNIQUE="false" FIELDS="userid"/>
-        <INDEX NAME="course" UNIQUE="false" FIELDS="course"/>
-        <INDEX NAME="criteriaid" UNIQUE="false" FIELDS="criteriaid"/>
-        <INDEX NAME="timecompleted" UNIQUE="false" FIELDS="timecompleted"/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="local_recompletion_cmc" COMMENT="archive of course_modules_completion table">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="coursemoduleid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Activity that has been completed (or not)."/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="ID of user who has (or hasn't) completed the activity."/>
-        <FIELD NAME="completionstate" TYPE="int" LENGTH="1" NOTNULL="true" SEQUENCE="false" COMMENT="Whether or not the user has completed the activity. Available states: 0 = not completed [if there's no row in this table, that also counts as 0] 1 = completed 2 = completed, show passed 3 = completed, show failed"/>
-        <FIELD NAME="viewed" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="Tracks whether or not this activity has been viewed. NULL = we are not tracking viewed for this activity 0 = not viewed 1 = viewed"/>
-        <FIELD NAME="overrideby" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Tracks whether this completion state has been set manually to override a previous state."/>
-        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Time at which the completion state last changed."/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="coursemoduleid" UNIQUE="false" FIELDS="coursemoduleid" COMMENT="For quick access via course-module (e.g. when displaying course module settings page and we need to determine whether anyone has completed it)."/>
-        <INDEX NAME="course" UNIQUE="false" FIELDS="course"/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="local_recompletion_cmv" COMMENT="Tracks the completion viewed (viewed with cmid/userid and otherwise no row) of each user on each activity.">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="coursemoduleid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Activity that has been viewed (or not)."/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="ID of user who has (or hasn't) viewed the activity."/>
-        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Time at which the completion viewed created."/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="coursemoduleid" UNIQUE="false" FIELDS="coursemoduleid" COMMENT="For quick access via course-module (e.g. when displaying course module settings page and we need to determine whether anyone has completed it)."/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="local_recompletion_qa" COMMENT="archive of quiz attempts table">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" COMMENT="Standard Moodle primary key."/>
-        <FIELD NAME="quiz" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Foreign key reference to the quiz that was attempted."/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Foreign key reference to the user whose attempt this is."/>
-        <FIELD NAME="attempt" TYPE="int" LENGTH="6" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Sequentially numbers this student's attempts at this quiz."/>
-        <FIELD NAME="uniqueid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Foreign key reference to the question_usage that holds the details of the the question_attempts that make up this quiz attempt."/>
-        <FIELD NAME="layout" TYPE="text" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="currentpage" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="preview" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="state" TYPE="char" LENGTH="16" NOTNULL="true" DEFAULT="inprogress" SEQUENCE="false" COMMENT="The current state of the attempts. 'inprogress', 'overdue', 'finished' or 'abandoned'."/>
-        <FIELD NAME="timestart" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Time when the attempt was started."/>
-        <FIELD NAME="timefinish" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Time when the attempt was submitted. 0 if the attempt has not been submitted yet."/>
-        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Last modified time."/>
-        <FIELD NAME="timecheckstate" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="Next time quiz cron should check attempt for state changes.  NULL means never check."/>
-        <FIELD NAME="sumgrades" TYPE="number" LENGTH="10" NOTNULL="false" SEQUENCE="false" DECIMALS="5" COMMENT="Total marks for this attempt."/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-        <KEY NAME="quiz" TYPE="foreign" FIELDS="quiz" REFTABLE="quiz" REFFIELDS="id"/>
-        <KEY NAME="userid" TYPE="foreign" FIELDS="userid" REFTABLE="user" REFFIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="state-timecheckstate" UNIQUE="false" FIELDS="state, timecheckstate"/>
-        <INDEX NAME="course" UNIQUE="false" FIELDS="course"/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="local_recompletion_qg" COMMENT="archive of quiz grades table">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="quiz" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Foreign key references quiz.id."/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Foreign key references user.id."/>
-        <FIELD NAME="grade" TYPE="number" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" DECIMALS="5" COMMENT="The overall grade from the quiz. Not affected by overrides in the gradebook."/>
-        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="The last time this grade changed."/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-        <KEY NAME="quiz" TYPE="foreign" FIELDS="quiz" REFTABLE="quiz" REFFIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="userid" UNIQUE="false" FIELDS="userid"/>
-        <INDEX NAME="course" UNIQUE="false" FIELDS="course"/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="local_recompletion_sa" COMMENT="archive of mdl_scorm_attempt table">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="scormid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="attempt" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-        <KEY NAME="userid" TYPE="foreign" FIELDS="userid" REFTABLE="user" REFFIELDS="id"/>
-        <KEY NAME="scormid" TYPE="foreign" FIELDS="scormid" REFTABLE="scorm" REFFIELDS="id"/>
-        <KEY NAME="courseid" TYPE="foreign" FIELDS="courseid" REFTABLE="course" REFFIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="userid" UNIQUE="false" FIELDS="userid"/>
-        <INDEX NAME="attempt" UNIQUE="false" FIELDS="attempt"/>
-        <INDEX NAME="courseid" UNIQUE="false" FIELDS="courseid"/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="local_recompletion_ssv" COMMENT="archive of mdl_scorm_scoes_value table">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="scoid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="attemptid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
-        <FIELD NAME="elementid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="value" TYPE="text" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-        <KEY NAME="scoid" TYPE="foreign" FIELDS="scoid" REFTABLE="scorm_scoes" REFFIELDS="id"/>
-        <KEY NAME="attemptid" TYPE="foreign" FIELDS="attemptid" REFTABLE="scorm_attempt" REFFIELDS="id"/>
-        <KEY NAME="elementid" TYPE="foreign" FIELDS="elementid" REFTABLE="scorm_element" REFFIELDS="id"/>
-        <KEY NAME="courseid" TYPE="foreign" FIELDS="courseid" REFTABLE="course" REFFIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="attemptid" UNIQUE="false" FIELDS="attemptid"/>
-        <INDEX NAME="elementid" UNIQUE="false" FIELDS="elementid"/>
-        <INDEX NAME="courseid" UNIQUE="false" FIELDS="courseid"/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="local_recompletion_config" COMMENT="Configuration for recompletion.">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Course id"/>
-        <FIELD NAME="name" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false" COMMENT="Name of config value"/>
-        <FIELD NAME="value" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="Value of config"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="course" UNIQUE="false" FIELDS="course"/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="local_recompletion_ltia" COMMENT="User access log and gradeback data">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="toolid" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="lastgrade" TYPE="number" LENGTH="10" NOTNULL="true" SEQUENCE="false" DECIMALS="5" COMMENT="The last grade that was sent"/>
-        <FIELD NAME="lastaccess" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="The time the user was created"/>
-        <FIELD NAME="timecreated" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="The time the user was created"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-    </TABLE>
-    <TABLE NAME="local_recompletion_qr" COMMENT="Copy of questionnaire_response table data">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="originalresponseid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="questionnaireid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="submitted" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="complete" TYPE="char" LENGTH="1" NOTNULL="true" DEFAULT="n" SEQUENCE="false"/>
-        <FIELD NAME="grade" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Grade awarded"/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-        <KEY NAME="questionnaireid" TYPE="foreign" FIELDS="questionnaireid" REFTABLE="questionnaire" REFFIELDS="id"/>
-      </KEYS>
-    </TABLE>
-    <TABLE NAME="local_recompletion_qr_bool" COMMENT="questionnaire_response_bool table retrofitted from MySQL">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="response_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="question_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="choice_id" TYPE="char" LENGTH="1" NOTNULL="true" DEFAULT="y" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="response_question" UNIQUE="false" FIELDS="response_id, question_id"/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="local_recompletion_qr_date" COMMENT="questionnaire_response_date table retrofitted from MySQL">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="response_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="question_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="response" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="response_question" UNIQUE="false" FIELDS="response_id, question_id"/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="local_recompletion_qr_m" COMMENT="questionnaire_resp_multiple table retrofitted from MySQL">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="response_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="question_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="choice_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="response_question" UNIQUE="false" FIELDS="response_id, question_id, choice_id"/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="local_recompletion_qr_other" COMMENT="questionnaire_response_other table retrofitted from MySQL">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="response_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="question_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="choice_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="response" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="response_question" UNIQUE="false" FIELDS="response_id, question_id, choice_id"/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="local_recompletion_qr_rank" COMMENT="questionnaire_response_rank table retrofitted from MySQL">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="response_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="question_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="choice_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="rankvalue" TYPE="int" LENGTH="11" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="response_question" UNIQUE="false" FIELDS="response_id, question_id, choice_id"/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="local_recompletion_qr_single" COMMENT="questionnaire_resp_single table retrofitted from MySQL">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="response_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="question_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="choice_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="response_question" UNIQUE="false" FIELDS="response_id, question_id"/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="local_recompletion_qr_text" COMMENT="questionnaire_response_text table retrofitted from MySQL">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="response_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="question_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="response" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="response_question" UNIQUE="false" FIELDS="response_id, question_id"/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="local_recompletion_cha" COMMENT="archive of choice_answers table">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="choiceid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="optionid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-        <KEY NAME="choiceid" TYPE="foreign" FIELDS="choiceid" REFTABLE="choice" REFFIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="course" UNIQUE="false" FIELDS="course"/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="local_recompletion_ccert_is" COMMENT="archive of customcert_issues table">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="customcertid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="code" TYPE="char" LENGTH="40" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="emailed" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="Primary key for customcert_issues"/>
-        <KEY NAME="customcert" TYPE="foreign" FIELDS="customcertid" REFTABLE="customcert" REFFIELDS="id"/>
-      </KEYS>
-      <INDEXES>
-        <INDEX NAME="course" UNIQUE="false" FIELDS="course"/>
-      </INDEXES>
-    </TABLE>
-    <TABLE NAME="local_recompletion_hvp" COMMENT="Archive for hvp_content_user_data table">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="user_id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Id for the user answering this H5P"/>
-        <FIELD NAME="hvp_id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Id of hvp content in the 'hvp' table"/>
-        <FIELD NAME="sub_content_id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Subcontent id of hvp content, 0 if this is not subcontent"/>
-        <FIELD NAME="data_id" TYPE="char" LENGTH="127" NOTNULL="false" SEQUENCE="false" COMMENT="The data type identifier"/>
-        <FIELD NAME="data" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="The actual user data that was stored."/>
-        <FIELD NAME="preloaded" TYPE="int" LENGTH="1" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="delete_on_content_change" TYPE="int" LENGTH="1" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Extra course to help restoring if needed."/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-    </TABLE>
-    <TABLE NAME="local_recompletion_h5p" COMMENT="Users attempts inside H5P activities (h5pactivity_attempts)">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="originalattemptid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Temp storage of original attempt ID from h5pactivity_attempts."/>
-        <FIELD NAME="h5pactivityid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="H5P activity ID"/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="20" NOTNULL="true" SEQUENCE="false" COMMENT="Attempt user ID"/>
-        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="attempt" TYPE="int" LENGTH="6" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Attempt number"/>
-        <FIELD NAME="rawscore" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="maxscore" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="scaled" TYPE="number" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" DECIMALS="5" COMMENT="Number 0..1 that reflects the performance of the learner"/>
-        <FIELD NAME="duration" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="Number of second inverted in that attempt (provided by the statement)"/>
-        <FIELD NAME="completion" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="Store the xAPI tracking completion result."/>
-        <FIELD NAME="success" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="Store the xAPI tracking success result."/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Extra course to help restoring if needed."/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-    </TABLE>
-    <TABLE NAME="local_recompletion_h5pr" COMMENT="H5Pactivities_attempts tracking info">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="attemptid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="h5pactivity_attempts ID from local_recompletion_h5p."/>
-        <FIELD NAME="subcontent" TYPE="char" LENGTH="128" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="interactiontype" TYPE="char" LENGTH="128" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="description" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="correctpattern" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Correct Pattern in xAPI format"/>
-        <FIELD NAME="response" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="User response data in xAPI forma"/>
-        <FIELD NAME="additionals" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Extra subcontent information in JSON format"/>
-        <FIELD NAME="rawscore" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="maxscore" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="duration" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false" COMMENT="Seconds inverted in this result (exctracted directly from statement)"/>
-        <FIELD NAME="completion" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="Store the xAPI tracking completion result."/>
-        <FIELD NAME="success" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="Store the xAPI tracking success result."/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Extra course to help restoring if needed."/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-    </TABLE>
-    <TABLE NAME="local_recompletion_la" COMMENT="Archive for lesson_attempts">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="lessonid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="pageid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="answerid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="retry" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="correct" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="useranswer" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="timeseen" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-    </TABLE>
-    <TABLE NAME="local_recompletion_lg" COMMENT="Archive of lesson_grades">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="lessonid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="grade" TYPE="float" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="late" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="completed" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-    </TABLE>
-    <TABLE NAME="local_recompletion_lt" COMMENT="Archive of lesson_timer">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="lessonid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="starttime" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="lessontime" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="completed" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="timemodifiedoffline" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-    </TABLE>
-    <TABLE NAME="local_recompletion_lb" COMMENT="Archive of lesson_branch">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="lessonid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="pageid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="retry" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="flag" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="timeseen" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="nextpageid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-    </TABLE>
-    <TABLE NAME="local_recompletion_lo" COMMENT="Archive of lesson_overrides">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="lessonid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="groupid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="available" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="deadline" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="timelimit" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="review" TYPE="int" LENGTH="3" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="maxattempts" TYPE="int" LENGTH="3" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="retake" TYPE="int" LENGTH="3" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="password" TYPE="char" LENGTH="32" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-    </TABLE>
-    <TABLE NAME="local_recompletion_hpa" COMMENT="Archived records for hotpot_attempts table">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="hotpotid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="starttime" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="endtime" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="score" TYPE="int" LENGTH="6" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="penalties" TYPE="int" LENGTH="6" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="attempt" TYPE="int" LENGTH="6" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="timestart" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="timefinish" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="status" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
-        <FIELD NAME="clickreportid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-    </TABLE>
-    <TABLE NAME="local_recompletion_cert" COMMENT="archive of certificate_issues table">
-      <FIELDS>
-        <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="certificateid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="code" TYPE="char" LENGTH="40" NOTNULL="false" SEQUENCE="false"/>
-        <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-        <FIELD NAME="printdate" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Date printed on a certificate. It could be course completion, completion of one of the activities or issued date. Record it for possible verification."/>
-        <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
-      </FIELDS>
-      <KEYS>
-        <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
-      </KEYS>
-    </TABLE>
-  </TABLES>
+    <TABLES>
+        <TABLE NAME="local_recompletion_cc" COMMENT="archive of course_completions table">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="timeenrolled" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="timestarted" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="timecompleted" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="reaggregate" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="userid" UNIQUE="false" FIELDS="userid"/>
+                <INDEX NAME="course" UNIQUE="false" FIELDS="course"/>
+                <INDEX NAME="timecompleted" UNIQUE="false" FIELDS="timecompleted"/>
+            </INDEXES>
+        </TABLE>
+        <TABLE NAME="local_recompletion_cc_cc" COMMENT="archive of course_completion_crit_compl">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="criteriaid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Completion criteria this references"/>
+                <FIELD NAME="gradefinal" TYPE="number" LENGTH="10" NOTNULL="false" SEQUENCE="false" DECIMALS="5"
+                       COMMENT="The final grade for the course (included regardless of whether a passing grade was required)"/>
+                <FIELD NAME="unenroled" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false" COMMENT="Timestamp when the user was unenroled"/>
+                <FIELD NAME="timecompleted" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="userid" UNIQUE="false" FIELDS="userid"/>
+                <INDEX NAME="course" UNIQUE="false" FIELDS="course"/>
+                <INDEX NAME="criteriaid" UNIQUE="false" FIELDS="criteriaid"/>
+                <INDEX NAME="timecompleted" UNIQUE="false" FIELDS="timecompleted"/>
+            </INDEXES>
+        </TABLE>
+        <TABLE NAME="local_recompletion_cmc" COMMENT="archive of course_modules_completion table">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="coursemoduleid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Activity that has been completed (or not)."/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="ID of user who has (or hasn't) completed the activity."/>
+                <FIELD NAME="completionstate" TYPE="int" LENGTH="1" NOTNULL="true" SEQUENCE="false"
+                       COMMENT="Whether or not the user has completed the activity. Available states: 0 = not completed [if there's no row in this table, that also counts as 0] 1 = completed 2 = completed, show passed 3 = completed, show failed"/>
+                <FIELD NAME="viewed" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false"
+                       COMMENT="Tracks whether or not this activity has been viewed. NULL = we are not tracking viewed for this activity 0 = not viewed 1 = viewed"/>
+                <FIELD NAME="overrideby" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"
+                       COMMENT="Tracks whether this completion state has been set manually to override a previous state."/>
+                <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Time at which the completion state last changed."/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="coursemoduleid" UNIQUE="false" FIELDS="coursemoduleid"
+                       COMMENT="For quick access via course-module (e.g. when displaying course module settings page and we need to determine whether anyone has completed it)."/>
+                <INDEX NAME="course" UNIQUE="false" FIELDS="course"/>
+            </INDEXES>
+        </TABLE>
+        <TABLE NAME="local_recompletion_cmv" COMMENT="Tracks the completion viewed (viewed with cmid/userid and otherwise no row) of each user on each activity.">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="coursemoduleid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Activity that has been viewed (or not)."/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="ID of user who has (or hasn't) viewed the activity."/>
+                <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Time at which the completion viewed created."/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="coursemoduleid" UNIQUE="false" FIELDS="coursemoduleid"
+                       COMMENT="For quick access via course-module (e.g. when displaying course module settings page and we need to determine whether anyone has completed it)."/>
+            </INDEXES>
+        </TABLE>
+        <TABLE NAME="local_recompletion_qa" COMMENT="archive of quiz attempts table">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" COMMENT="Standard Moodle primary key."/>
+                <FIELD NAME="quiz" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Foreign key reference to the quiz that was attempted."/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Foreign key reference to the user whose attempt this is."/>
+                <FIELD NAME="attempt" TYPE="int" LENGTH="6" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Sequentially numbers this student's attempts at this quiz."/>
+                <FIELD NAME="uniqueid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"
+                       COMMENT="Foreign key reference to the question_usage that holds the details of the the question_attempts that make up this quiz attempt."/>
+                <FIELD NAME="layout" TYPE="text" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="currentpage" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="preview" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="state" TYPE="char" LENGTH="16" NOTNULL="true" DEFAULT="inprogress" SEQUENCE="false"
+                       COMMENT="The current state of the attempts. 'inprogress', 'overdue', 'finished' or 'abandoned'."/>
+                <FIELD NAME="timestart" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Time when the attempt was started."/>
+                <FIELD NAME="timefinish" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"
+                       COMMENT="Time when the attempt was submitted. 0 if the attempt has not been submitted yet."/>
+                <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Last modified time."/>
+                <FIELD NAME="timecheckstate" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false"
+                       COMMENT="Next time quiz cron should check attempt for state changes.  NULL means never check."/>
+                <FIELD NAME="sumgrades" TYPE="number" LENGTH="10" NOTNULL="false" SEQUENCE="false" DECIMALS="5" COMMENT="Total marks for this attempt."/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+                <KEY NAME="quiz" TYPE="foreign" FIELDS="quiz" REFTABLE="quiz" REFFIELDS="id"/>
+                <KEY NAME="userid" TYPE="foreign" FIELDS="userid" REFTABLE="user" REFFIELDS="id"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="state-timecheckstate" UNIQUE="false" FIELDS="state, timecheckstate"/>
+                <INDEX NAME="course" UNIQUE="false" FIELDS="course"/>
+            </INDEXES>
+        </TABLE>
+        <TABLE NAME="local_recompletion_qg" COMMENT="archive of quiz grades table">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="quiz" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Foreign key references quiz.id."/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Foreign key references user.id."/>
+                <FIELD NAME="grade" TYPE="number" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" DECIMALS="5"
+                       COMMENT="The overall grade from the quiz. Not affected by overrides in the gradebook."/>
+                <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="The last time this grade changed."/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+                <KEY NAME="quiz" TYPE="foreign" FIELDS="quiz" REFTABLE="quiz" REFFIELDS="id"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="userid" UNIQUE="false" FIELDS="userid"/>
+                <INDEX NAME="course" UNIQUE="false" FIELDS="course"/>
+            </INDEXES>
+        </TABLE>
+        <TABLE NAME="local_recompletion_sa" COMMENT="archive of mdl_scorm_attempt table">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="scormid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="attempt" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+                <KEY NAME="userid" TYPE="foreign" FIELDS="userid" REFTABLE="user" REFFIELDS="id"/>
+                <KEY NAME="scormid" TYPE="foreign" FIELDS="scormid" REFTABLE="scorm" REFFIELDS="id"/>
+                <KEY NAME="courseid" TYPE="foreign" FIELDS="courseid" REFTABLE="course" REFFIELDS="id"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="userid" UNIQUE="false" FIELDS="userid"/>
+                <INDEX NAME="attempt" UNIQUE="false" FIELDS="attempt"/>
+                <INDEX NAME="courseid" UNIQUE="false" FIELDS="courseid"/>
+            </INDEXES>
+        </TABLE>
+        <TABLE NAME="local_recompletion_ssv" COMMENT="archive of mdl_scorm_scoes_value table">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="scoid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="attemptid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
+                <FIELD NAME="elementid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="value" TYPE="text" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="courseid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+                <KEY NAME="scoid" TYPE="foreign" FIELDS="scoid" REFTABLE="scorm_scoes" REFFIELDS="id"/>
+                <KEY NAME="attemptid" TYPE="foreign" FIELDS="attemptid" REFTABLE="scorm_attempt" REFFIELDS="id"/>
+                <KEY NAME="elementid" TYPE="foreign" FIELDS="elementid" REFTABLE="scorm_element" REFFIELDS="id"/>
+                <KEY NAME="courseid" TYPE="foreign" FIELDS="courseid" REFTABLE="course" REFFIELDS="id"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="attemptid" UNIQUE="false" FIELDS="attemptid"/>
+                <INDEX NAME="elementid" UNIQUE="false" FIELDS="elementid"/>
+                <INDEX NAME="courseid" UNIQUE="false" FIELDS="courseid"/>
+            </INDEXES>
+        </TABLE>
+        <TABLE NAME="local_recompletion_config" COMMENT="Configuration for recompletion.">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Course id"/>
+                <FIELD NAME="name" TYPE="char" LENGTH="100" NOTNULL="true" SEQUENCE="false" COMMENT="Name of config value"/>
+                <FIELD NAME="value" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="Value of config"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="course" UNIQUE="false" FIELDS="course"/>
+            </INDEXES>
+        </TABLE>
+        <TABLE NAME="local_recompletion_ltia" COMMENT="User access log and gradeback data">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="toolid" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="lastgrade" TYPE="number" LENGTH="10" NOTNULL="true" SEQUENCE="false" DECIMALS="5" COMMENT="The last grade that was sent"/>
+                <FIELD NAME="lastaccess" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="The time the user was created"/>
+                <FIELD NAME="timecreated" TYPE="int" LENGTH="11" NOTNULL="true" SEQUENCE="false" COMMENT="The time the user was created"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+        </TABLE>
+        <TABLE NAME="local_recompletion_qr" COMMENT="Copy of questionnaire_response table data">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="originalresponseid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="questionnaireid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="submitted" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="complete" TYPE="char" LENGTH="1" NOTNULL="true" DEFAULT="n" SEQUENCE="false"/>
+                <FIELD NAME="grade" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Grade awarded"/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+                <KEY NAME="questionnaireid" TYPE="foreign" FIELDS="questionnaireid" REFTABLE="questionnaire" REFFIELDS="id"/>
+            </KEYS>
+        </TABLE>
+        <TABLE NAME="local_recompletion_qr_bool" COMMENT="questionnaire_response_bool table retrofitted from MySQL">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="response_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="question_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="choice_id" TYPE="char" LENGTH="1" NOTNULL="true" DEFAULT="y" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="response_question" UNIQUE="false" FIELDS="response_id, question_id"/>
+            </INDEXES>
+        </TABLE>
+        <TABLE NAME="local_recompletion_qr_date" COMMENT="questionnaire_response_date table retrofitted from MySQL">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="response_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="question_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="response" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="response_question" UNIQUE="false" FIELDS="response_id, question_id"/>
+            </INDEXES>
+        </TABLE>
+        <TABLE NAME="local_recompletion_qr_m" COMMENT="questionnaire_resp_multiple table retrofitted from MySQL">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="response_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="question_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="choice_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="response_question" UNIQUE="false" FIELDS="response_id, question_id, choice_id"/>
+            </INDEXES>
+        </TABLE>
+        <TABLE NAME="local_recompletion_qr_other" COMMENT="questionnaire_response_other table retrofitted from MySQL">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="response_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="question_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="choice_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="response" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="response_question" UNIQUE="false" FIELDS="response_id, question_id, choice_id"/>
+            </INDEXES>
+        </TABLE>
+        <TABLE NAME="local_recompletion_qr_rank" COMMENT="questionnaire_response_rank table retrofitted from MySQL">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="response_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="question_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="choice_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="rankvalue" TYPE="int" LENGTH="11" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="response_question" UNIQUE="false" FIELDS="response_id, question_id, choice_id"/>
+            </INDEXES>
+        </TABLE>
+        <TABLE NAME="local_recompletion_qr_single" COMMENT="questionnaire_resp_single table retrofitted from MySQL">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="response_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="question_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="choice_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="response_question" UNIQUE="false" FIELDS="response_id, question_id"/>
+            </INDEXES>
+        </TABLE>
+        <TABLE NAME="local_recompletion_qr_text" COMMENT="questionnaire_response_text table retrofitted from MySQL">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="response_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="question_id" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="response" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="response_question" UNIQUE="false" FIELDS="response_id, question_id"/>
+            </INDEXES>
+        </TABLE>
+        <TABLE NAME="local_recompletion_cha" COMMENT="archive of choice_answers table">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="choiceid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="optionid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+                <KEY NAME="choiceid" TYPE="foreign" FIELDS="choiceid" REFTABLE="choice" REFFIELDS="id"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="course" UNIQUE="false" FIELDS="course"/>
+            </INDEXES>
+        </TABLE>
+        <TABLE NAME="local_recompletion_ccert_is" COMMENT="archive of customcert_issues table">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="customcertid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="code" TYPE="char" LENGTH="40" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="emailed" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id" COMMENT="Primary key for customcert_issues"/>
+                <KEY NAME="customcert" TYPE="foreign" FIELDS="customcertid" REFTABLE="customcert" REFFIELDS="id"/>
+            </KEYS>
+            <INDEXES>
+                <INDEX NAME="course" UNIQUE="false" FIELDS="course"/>
+            </INDEXES>
+        </TABLE>
+        <TABLE NAME="local_recompletion_hvp" COMMENT="Archive for hvp_content_user_data table">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="user_id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Id for the user answering this H5P"/>
+                <FIELD NAME="hvp_id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Id of hvp content in the 'hvp' table"/>
+                <FIELD NAME="sub_content_id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Subcontent id of hvp content, 0 if this is not subcontent"/>
+                <FIELD NAME="data_id" TYPE="char" LENGTH="127" NOTNULL="false" SEQUENCE="false" COMMENT="The data type identifier"/>
+                <FIELD NAME="data" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="The actual user data that was stored."/>
+                <FIELD NAME="preloaded" TYPE="int" LENGTH="1" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="delete_on_content_change" TYPE="int" LENGTH="1" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Extra course to help restoring if needed."/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+        </TABLE>
+        <TABLE NAME="local_recompletion_h5p" COMMENT="Users attempts inside H5P activities (h5pactivity_attempts)">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="originalattemptid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="Temp storage of original attempt ID from h5pactivity_attempts."/>
+                <FIELD NAME="h5pactivityid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="H5P activity ID"/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="20" NOTNULL="true" SEQUENCE="false" COMMENT="Attempt user ID"/>
+                <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="attempt" TYPE="int" LENGTH="6" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Attempt number"/>
+                <FIELD NAME="rawscore" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="maxscore" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="scaled" TYPE="number" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" DECIMALS="5"
+                       COMMENT="Number 0..1 that reflects the performance of the learner"/>
+                <FIELD NAME="duration" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false"
+                       COMMENT="Number of second inverted in that attempt (provided by the statement)"/>
+                <FIELD NAME="completion" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="Store the xAPI tracking completion result."/>
+                <FIELD NAME="success" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="Store the xAPI tracking success result."/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Extra course to help restoring if needed."/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+        </TABLE>
+        <TABLE NAME="local_recompletion_h5pr" COMMENT="H5Pactivities_attempts tracking info">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="attemptid" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false" COMMENT="h5pactivity_attempts ID from local_recompletion_h5p."/>
+                <FIELD NAME="subcontent" TYPE="char" LENGTH="128" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+                <FIELD NAME="interactiontype" TYPE="char" LENGTH="128" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="description" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="correctpattern" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Correct Pattern in xAPI format"/>
+                <FIELD NAME="response" TYPE="text" NOTNULL="true" SEQUENCE="false" COMMENT="User response data in xAPI forma"/>
+                <FIELD NAME="additionals" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Extra subcontent information in JSON format"/>
+                <FIELD NAME="rawscore" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="maxscore" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="duration" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false"
+                       COMMENT="Seconds inverted in this result (exctracted directly from statement)"/>
+                <FIELD NAME="completion" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="Store the xAPI tracking completion result."/>
+                <FIELD NAME="success" TYPE="int" LENGTH="1" NOTNULL="false" SEQUENCE="false" COMMENT="Store the xAPI tracking success result."/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="Extra course to help restoring if needed."/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+        </TABLE>
+        <TABLE NAME="local_recompletion_la" COMMENT="Archive for lesson_attempts">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="lessonid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="pageid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="answerid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="retry" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="correct" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="useranswer" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="timeseen" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+        </TABLE>
+        <TABLE NAME="local_recompletion_lg" COMMENT="Archive of lesson_grades">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="lessonid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="grade" TYPE="float" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="late" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="completed" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+        </TABLE>
+        <TABLE NAME="local_recompletion_lt" COMMENT="Archive of lesson_timer">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="lessonid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="starttime" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="lessontime" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="completed" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="timemodifiedoffline" TYPE="int" LENGTH="10" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+        </TABLE>
+        <TABLE NAME="local_recompletion_lb" COMMENT="Archive of lesson_branch">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="lessonid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="pageid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="retry" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="flag" TYPE="int" LENGTH="3" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="timeseen" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="nextpageid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+        </TABLE>
+        <TABLE NAME="local_recompletion_lo" COMMENT="Archive of lesson_overrides">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="lessonid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="groupid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="available" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="deadline" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="timelimit" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="review" TYPE="int" LENGTH="3" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="maxattempts" TYPE="int" LENGTH="3" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="retake" TYPE="int" LENGTH="3" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="password" TYPE="char" LENGTH="32" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+        </TABLE>
+        <TABLE NAME="local_recompletion_hpa" COMMENT="Archived records for hotpot_attempts table">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="hotpotid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="starttime" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="endtime" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="score" TYPE="int" LENGTH="6" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="penalties" TYPE="int" LENGTH="6" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="attempt" TYPE="int" LENGTH="6" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="timestart" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="timefinish" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="status" TYPE="int" LENGTH="4" NOTNULL="true" DEFAULT="1" SEQUENCE="false"/>
+                <FIELD NAME="clickreportid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="timemodified" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+        </TABLE>
+        <TABLE NAME="local_recompletion_cert" COMMENT="archive of certificate_issues table">
+            <FIELDS>
+                <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
+                <FIELD NAME="userid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="certificateid" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="code" TYPE="char" LENGTH="40" NOTNULL="false" SEQUENCE="false"/>
+                <FIELD NAME="timecreated" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+                <FIELD NAME="printdate" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"
+                       COMMENT="Date printed on a certificate. It could be course completion, completion of one of the activities or issued date. Record it for possible verification."/>
+                <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" DEFAULT="0" SEQUENCE="false"/>
+            </FIELDS>
+            <KEYS>
+                <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
+            </KEYS>
+        </TABLE>
+    </TABLES>
 </XMLDB>

--- a/db/services.php
+++ b/db/services.php
@@ -27,12 +27,12 @@ defined('MOODLE_INTERNAL') || die;
 
 $functions = [
 
-    'local_recompletion_reset_course' => [
-        'classname'     => 'local_recompletion_external',
-        'methodname'    => 'reset_course',
-        'classpath'     => 'local/recompletion/externallib.php',
-        'description'   => 'Reset course completion for a given course and user.',
-        'type'          => 'write',
-        'capabilities'  => 'local/recompletion:manage'
-    ],
+        'local_recompletion_reset_course' => [
+                'classname' => 'local_recompletion_external',
+                'methodname' => 'reset_course',
+                'classpath' => 'local/recompletion/externallib.php',
+                'description' => 'Reset course completion for a given course and user.',
+                'type' => 'write',
+                'capabilities' => 'local/recompletion:manage',
+        ],
 ];

--- a/db/tasks.php
+++ b/db/tasks.php
@@ -25,14 +25,14 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$tasks = array(
-    array(
-        'classname' => 'local_recompletion\task\check_recompletion',
-        'blocking' => 0,
-        'minute' => 'R',
-        'hour' => 'R',
-        'day' => '*',
-        'dayofweek' => '*',
-        'month' => '*'
-    )
-);
+$tasks = [
+        [
+                'classname' => 'local_recompletion\task\check_recompletion',
+                'blocking' => 0,
+                'minute' => 'R',
+                'hour' => 'R',
+                'day' => '*',
+                'dayofweek' => '*',
+                'month' => '*',
+        ],
+];

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -23,8 +23,11 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use core\output\notification;
+
 /**
  * upgrade this recompletion
+ *
  * @param int $oldversion The old version of the assign module
  * @return bool
  */
@@ -48,12 +51,12 @@ function xmldb_local_recompletion_upgrade($oldversion) {
         $table->add_field('reaggregate', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
 
         // Adding keys to table local_recompletion_cc.
-        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
 
         // Adding indexes to table local_recompletion_cc.
-        $table->add_index('userid', XMLDB_INDEX_NOTUNIQUE, array('userid'));
-        $table->add_index('course', XMLDB_INDEX_NOTUNIQUE, array('course'));
-        $table->add_index('timecompleted', XMLDB_INDEX_NOTUNIQUE, array('timecompleted'));
+        $table->add_index('userid', XMLDB_INDEX_NOTUNIQUE, ['userid']);
+        $table->add_index('course', XMLDB_INDEX_NOTUNIQUE, ['course']);
+        $table->add_index('timecompleted', XMLDB_INDEX_NOTUNIQUE, ['timecompleted']);
 
         // Conditionally launch create table for local_recompletion_cc.
         if (!$dbman->table_exists($table)) {
@@ -73,13 +76,13 @@ function xmldb_local_recompletion_upgrade($oldversion) {
         $table->add_field('timecompleted', XMLDB_TYPE_INTEGER, '10', null, null, null, null);
 
         // Adding keys to table local_recompletion_cc_cc.
-        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
 
         // Adding indexes to table local_recompletion_cc_cc.
-        $table->add_index('userid', XMLDB_INDEX_NOTUNIQUE, array('userid'));
-        $table->add_index('course', XMLDB_INDEX_NOTUNIQUE, array('course'));
-        $table->add_index('criteriaid', XMLDB_INDEX_NOTUNIQUE, array('criteriaid'));
-        $table->add_index('timecompleted', XMLDB_INDEX_NOTUNIQUE, array('timecompleted'));
+        $table->add_index('userid', XMLDB_INDEX_NOTUNIQUE, ['userid']);
+        $table->add_index('course', XMLDB_INDEX_NOTUNIQUE, ['course']);
+        $table->add_index('criteriaid', XMLDB_INDEX_NOTUNIQUE, ['criteriaid']);
+        $table->add_index('timecompleted', XMLDB_INDEX_NOTUNIQUE, ['timecompleted']);
 
         // Conditionally launch create table for local_recompletion_cc_cc.
         if (!$dbman->table_exists($table)) {
@@ -99,10 +102,10 @@ function xmldb_local_recompletion_upgrade($oldversion) {
         $table->add_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, null);
 
         // Adding keys to table local_recompletion_cmc.
-        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
 
         // Adding indexes to table local_recompletion_cmc.
-        $table->add_index('coursemoduleid', XMLDB_INDEX_NOTUNIQUE, array('coursemoduleid'));
+        $table->add_index('coursemoduleid', XMLDB_INDEX_NOTUNIQUE, ['coursemoduleid']);
 
         // Conditionally launch create table for local_recompletion_cmc.
         if (!$dbman->table_exists($table)) {
@@ -134,12 +137,12 @@ function xmldb_local_recompletion_upgrade($oldversion) {
         $table->add_field('sumgrades', XMLDB_TYPE_NUMBER, '10, 5', null, null, null, null);
 
         // Adding keys to table local_recompletion_qa.
-        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
-        $table->add_key('quiz', XMLDB_KEY_FOREIGN, array('quiz'), 'quiz', array('id'));
-        $table->add_key('userid', XMLDB_KEY_FOREIGN, array('userid'), 'user', array('id'));
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        $table->add_key('quiz', XMLDB_KEY_FOREIGN, ['quiz'], 'quiz', ['id']);
+        $table->add_key('userid', XMLDB_KEY_FOREIGN, ['userid'], 'user', ['id']);
 
         // Adding indexes to table local_recompletion_qa.
-        $table->add_index('state-timecheckstate', XMLDB_INDEX_NOTUNIQUE, array('state', 'timecheckstate'));
+        $table->add_index('state-timecheckstate', XMLDB_INDEX_NOTUNIQUE, ['state', 'timecheckstate']);
 
         // Conditionally launch create table for local_recompletion_qa.
         if (!$dbman->table_exists($table)) {
@@ -157,11 +160,11 @@ function xmldb_local_recompletion_upgrade($oldversion) {
         $table->add_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
 
         // Adding keys to table local_recompletion_qg.
-        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
-        $table->add_key('quiz', XMLDB_KEY_FOREIGN, array('quiz'), 'quiz', array('id'));
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        $table->add_key('quiz', XMLDB_KEY_FOREIGN, ['quiz'], 'quiz', ['id']);
 
         // Adding indexes to table local_recompletion_qg.
-        $table->add_index('userid', XMLDB_INDEX_NOTUNIQUE, array('userid'));
+        $table->add_index('userid', XMLDB_INDEX_NOTUNIQUE, ['userid']);
 
         // Conditionally launch create table for local_recompletion_qg.
         if (!$dbman->table_exists($table)) {
@@ -181,13 +184,13 @@ function xmldb_local_recompletion_upgrade($oldversion) {
         $table->add_field('timemodified', XMLDB_TYPE_INTEGER, '10', null, XMLDB_NOTNULL, null, '0');
 
         // Adding keys to table local_recompletion_sst.
-        $table->add_key('primary', XMLDB_KEY_PRIMARY, array('id'));
-        $table->add_key('scormid', XMLDB_KEY_FOREIGN, array('scormid'), 'scorm', array('id'));
-        $table->add_key('scoid', XMLDB_KEY_FOREIGN, array('scoid'), 'scorm_scoes', array('id'));
+        $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
+        $table->add_key('scormid', XMLDB_KEY_FOREIGN, ['scormid'], 'scorm', ['id']);
+        $table->add_key('scoid', XMLDB_KEY_FOREIGN, ['scoid'], 'scorm_scoes', ['id']);
 
         // Adding indexes to table local_recompletion_sst.
-        $table->add_index('userid', XMLDB_INDEX_NOTUNIQUE, array('userid'));
-        $table->add_index('element', XMLDB_INDEX_NOTUNIQUE, array('element'));
+        $table->add_index('userid', XMLDB_INDEX_NOTUNIQUE, ['userid']);
+        $table->add_index('element', XMLDB_INDEX_NOTUNIQUE, ['element']);
 
         // Conditionally launch create table for local_recompletion_sst.
         if (!$dbman->table_exists($table)) {
@@ -270,41 +273,41 @@ function xmldb_local_recompletion_upgrade($oldversion) {
     if ($oldversion < 2018071901) {
         // Convert old local_recompletion records to new structure.
         $recompletion = $DB->get_recordset('local_recompletion');
-        $newrecords = array();
+        $newrecords = [];
         foreach ($recompletion as $r) {
-            $newrecords[] = array('course' => $r->course,
-                'name' => 'enable',
-                'value' => $r->enable);
-            $newrecords[] = array('course' => $r->course,
-                'name' => 'recompletionduration',
-                'value' => $r->recompletionduration);
-            $newrecords[] = array('course' => $r->course,
-                'name' => 'deletegradedata',
-                'value' => $r->deletegradedata);
-            $newrecords[] = array('course' => $r->course,
-                'name' => 'quizdata',
-                'value' => $r->deletequizdata);
-            $newrecords[] = array('course' => $r->course,
-                'name' => 'deletescormdata',
-                'value' => $r->deletescormdata);
-            $newrecords[] = array('course' => $r->course,
-                'name' => 'archivecompletiondata',
-                'value' => $r->archivecompletiondata);
-            $newrecords[] = array('course' => $r->course,
-                'name' => 'archivequizdata',
-                'value' => $r->archivequizdata);
-            $newrecords[] = array('course' => $r->course,
-                'name' => 'archivescormdata',
-                'value' => $r->archivescormdata);
-            $newrecords[] = array('course' => $r->course,
-                'name' => 'recompletionemailenable',
-                'value' => $r->recompletionemailenable);
-            $newrecords[] = array('course' => $r->course,
-                'name' => 'recompletionemailsubject',
-                'value' => $r->recompletionemailsubject);
-            $newrecords[] = array('course' => $r->course,
-                'name' => 'recompletionemailbody',
-                'value' => $r->recompletionemailbody);
+            $newrecords[] = ['course' => $r->course,
+                    'name' => 'enable',
+                    'value' => $r->enable];
+            $newrecords[] = ['course' => $r->course,
+                    'name' => 'recompletionduration',
+                    'value' => $r->recompletionduration];
+            $newrecords[] = ['course' => $r->course,
+                    'name' => 'deletegradedata',
+                    'value' => $r->deletegradedata];
+            $newrecords[] = ['course' => $r->course,
+                    'name' => 'quizdata',
+                    'value' => $r->deletequizdata];
+            $newrecords[] = ['course' => $r->course,
+                    'name' => 'deletescormdata',
+                    'value' => $r->deletescormdata];
+            $newrecords[] = ['course' => $r->course,
+                    'name' => 'archivecompletiondata',
+                    'value' => $r->archivecompletiondata];
+            $newrecords[] = ['course' => $r->course,
+                    'name' => 'archivequizdata',
+                    'value' => $r->archivequizdata];
+            $newrecords[] = ['course' => $r->course,
+                    'name' => 'archivescormdata',
+                    'value' => $r->archivescormdata];
+            $newrecords[] = ['course' => $r->course,
+                    'name' => 'recompletionemailenable',
+                    'value' => $r->recompletionemailenable];
+            $newrecords[] = ['course' => $r->course,
+                    'name' => 'recompletionemailsubject',
+                    'value' => $r->recompletionemailsubject];
+            $newrecords[] = ['course' => $r->course,
+                    'name' => 'recompletionemailbody',
+                    'value' => $r->recompletionemailbody];
         }
         $recompletion->close();
         foreach ($newrecords as $id => $rec) {
@@ -597,7 +600,7 @@ function xmldb_local_recompletion_upgrade($oldversion) {
     if ($oldversion < 2023040300) {
 
         // Update the format of older recompletionemailbody field data to html.
-        $recompletionconfig = $DB->get_recordset('local_recompletion_config', array('name' => 'recompletionemailbody'));
+        $recompletionconfig = $DB->get_recordset('local_recompletion_config', ['name' => 'recompletionemailbody']);
         foreach ($recompletionconfig as $record) {
             $message = $record->value;
             if (strpos($message, '<') === false) {
@@ -605,8 +608,8 @@ function xmldb_local_recompletion_upgrade($oldversion) {
                 $messagehtml = text_to_html($message, null, false, true);
             } else {
                 // This is most probably the tag/newline soup known as FORMAT_MOODLE.
-                $messagehtml = format_text($message, FORMAT_MOODLE, array('para' => false,
-                    'newlines' => true, 'filter' => true));
+                $messagehtml = format_text($message, FORMAT_MOODLE, ['para' => false,
+                        'newlines' => true, 'filter' => true]);
             }
             // Update record with html formatted text.
             $record->value = $messagehtml;
@@ -1001,9 +1004,9 @@ function xmldb_local_recompletion_upgrade($oldversion) {
 
         // Adding keys to table local_recompletion_ssv.
         $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
-        $table->add_key('userid', XMLDB_KEY_FOREIGN, array('userid'), 'user', array('id'));
-        $table->add_key('scormid', XMLDB_KEY_FOREIGN, array('scormid'), 'scorm', array('id'));
-        $table->add_key('courseid', XMLDB_KEY_FOREIGN, array('courseid'), 'course', array('id'));
+        $table->add_key('userid', XMLDB_KEY_FOREIGN, ['userid'], 'user', ['id']);
+        $table->add_key('scormid', XMLDB_KEY_FOREIGN, ['scormid'], 'scorm', ['id']);
+        $table->add_key('courseid', XMLDB_KEY_FOREIGN, ['courseid'], 'course', ['id']);
 
         // Conditionally launch create table for local_recompletion_ssv.
         if (!$dbman->table_exists($table)) {
@@ -1024,10 +1027,10 @@ function xmldb_local_recompletion_upgrade($oldversion) {
 
         // Adding keys to table local_recompletion_ssv.
         $table->add_key('primary', XMLDB_KEY_PRIMARY, ['id']);
-        $table->add_key('scoid', XMLDB_KEY_FOREIGN, array('scoid'), 'scorm_scoes', array('id'));
-        $table->add_key('attemptid', XMLDB_KEY_FOREIGN, array('attemptid'), 'scorm_attempt', array('id'));
-        $table->add_key('elementid', XMLDB_KEY_FOREIGN, array('elementid'), 'scorm_element', array('id'));
-        $table->add_key('courseid', XMLDB_KEY_FOREIGN, array('courseid'), 'course', array('id'));
+        $table->add_key('scoid', XMLDB_KEY_FOREIGN, ['scoid'], 'scorm_scoes', ['id']);
+        $table->add_key('attemptid', XMLDB_KEY_FOREIGN, ['attemptid'], 'scorm_attempt', ['id']);
+        $table->add_key('elementid', XMLDB_KEY_FOREIGN, ['elementid'], 'scorm_element', ['id']);
+        $table->add_key('courseid', XMLDB_KEY_FOREIGN, ['courseid'], 'course', ['id']);
         // Conditionally launch create table for local_recompletion_ssv.
         if (!$dbman->table_exists($table)) {
             $dbman->create_table($table);
@@ -1036,9 +1039,9 @@ function xmldb_local_recompletion_upgrade($oldversion) {
         $total = $DB->count_records('local_recompletion_sst');
         if ($total > 500000) {
             // This site has a large number of user track records, lets warn that this next part may take some time.
-            $notification = new \core\output\notification(
-                get_string('largetrackupgrade', 'scorm', format_float($total, 0)),
-                \core\output\notification::NOTIFY_WARNING
+            $notification = new notification(
+                    get_string('largetrackupgrade', 'scorm', format_float($total, 0)),
+                    notification::NOTIFY_WARNING
             );
             $notification->set_show_closebutton(false);
             echo $OUTPUT->render($notification);
@@ -1067,24 +1070,24 @@ function xmldb_local_recompletion_upgrade($oldversion) {
     if ($oldversion < 2024071100) {
         // We renamed some site admin settings.
         $update = [
-            'assignattempts' => 'assign',
-            'choiceattempts' => 'choice',
-            'customcertcertificates' => 'customcert',
-            'h5pattempts' => 'h5pactivity',
-            'archiveh5p' => 'archiveh5pactivity',
-            'hotpotattempts' => 'hotpot',
-            'hvpattempts' => 'hvp',
-            'lessonattempts' => 'lesson',
-            'pulsenotifications' => 'pulse',
-            'questionnaireattempts' => 'questionnaire',
-            'quizattempts' => 'quiz',
-            'scormattempts' => 'scorm',
-            'schedule' => 'recompletionschedule',
-            'duration' => 'recompletionduration',
-            'emailenable' => 'recompletionemailenable',
-            'emailsubject' => 'recompletionemailsubject',
-            'emailbody' => 'recompletionemailbody',
-            'unenrolenable' => 'recompletionunenrolenable'
+                'assignattempts' => 'assign',
+                'choiceattempts' => 'choice',
+                'customcertcertificates' => 'customcert',
+                'h5pattempts' => 'h5pactivity',
+                'archiveh5p' => 'archiveh5pactivity',
+                'hotpotattempts' => 'hotpot',
+                'hvpattempts' => 'hvp',
+                'lessonattempts' => 'lesson',
+                'pulsenotifications' => 'pulse',
+                'questionnaireattempts' => 'questionnaire',
+                'quizattempts' => 'quiz',
+                'scormattempts' => 'scorm',
+                'schedule' => 'recompletionschedule',
+                'duration' => 'recompletionduration',
+                'emailenable' => 'recompletionemailenable',
+                'emailsubject' => 'recompletionemailsubject',
+                'emailbody' => 'recompletionemailbody',
+                'unenrolenable' => 'recompletionunenrolenable',
         ];
 
         foreach ($update as $old => $new) {

--- a/editcompletion.php
+++ b/editcompletion.php
@@ -23,19 +23,19 @@
  */
 
 require_once('../../config.php');
-require_once($CFG->dirroot.'/local/recompletion/locallib.php');
+require_once($CFG->dirroot . '/local/recompletion/locallib.php');
 
 $courseid = required_param('id', PARAM_INT);
-$userid   = optional_param('user', 0, PARAM_INT);
-$users   = optional_param_array('users', array(), PARAM_INT);
+$userid = optional_param('user', 0, PARAM_INT);
+$users = optional_param_array('users', [], PARAM_INT);
 
-$course = $DB->get_record('course', array('id' => $courseid), '*', MUST_EXIST);
+$course = $DB->get_record('course', ['id' => $courseid], '*', MUST_EXIST);
 require_login($course);
 
 $context = context_course::instance($course->id);
 require_capability('local/recompletion:manage', $context);
 
-$PAGE->set_url('/local/recompletion/editcompletion.php', array('id' => $course->id));
+$PAGE->set_url('/local/recompletion/editcompletion.php', ['id' => $course->id]);
 if (empty($users) && empty($userid)) {
     // The first time list hack.
     if ($post = data_submitted()) {
@@ -46,20 +46,20 @@ if (empty($users) && empty($userid)) {
         }
     }
     if (empty($users)) {
-        redirect($CFG->wwwroot.'/local/recompletion/participants.php?id='.$course->id,
-            get_string('nousersselected', 'local_recompletion'));
+        redirect($CFG->wwwroot . '/local/recompletion/participants.php?id=' . $course->id,
+                get_string('nousersselected', 'local_recompletion'));
     }
 
 }
 if (empty($users)) {
-    $users = array();
+    $users = [];
     $users[] = $userid;
     // Get this users current completion date and use that in the form.
-    $params = array(
-        'userid'    => $userid,
-        'course'    => $courseid
-    );
-    $ccompletion = new \completion_completion($params);
+    $params = [
+            'userid' => $userid,
+            'course' => $courseid,
+    ];
+    $ccompletion = new completion_completion($params);
     if ($ccompletion->is_complete()) {
         $date = $ccompletion->timecompleted;
     }
@@ -80,14 +80,14 @@ if ($resetcompletion && confirm_sesskey()) {
         $errors = $reset->reset_user($userid, $course, $config);
     }
 
-    redirect($CFG->wwwroot.'/local/recompletion/participants.php?id='.$course->id,
-        get_string('completionreset', 'local_recompletion'));
+    redirect($CFG->wwwroot . '/local/recompletion/participants.php?id=' . $course->id,
+            get_string('completionreset', 'local_recompletion'));
 }
 
 $form = new local_recompletion_coursecompletion_form('editcompletion.php', [
-    'course' => $courseid,
-    'users' => $users,
-    'date' => $date,
+        'course' => $courseid,
+        'users' => $users,
+        'date' => $date,
 ]);
 
 if ($form->is_cancelled()) {
@@ -97,7 +97,7 @@ if ($form->is_cancelled()) {
         // Update course completion.
         local_recompletion_update_course_completion($courseid, $users, $data->newcompletion);
         redirect($CFG->wwwroot . '/local/recompletion/participants.php?id=' . $course->id,
-            get_string('completionupdated', 'local_recompletion'));
+                get_string('completionupdated', 'local_recompletion'));
     }
 }
 

--- a/externallib.php
+++ b/externallib.php
@@ -32,6 +32,7 @@ require_once("$CFG->libdir/grade/grade_grade.php");
 
 /**
  * local recompletion functions
+ *
  * @author     Noémie Ariste <noemie.ariste@catalyst.net.nz>
  * @copyright  2024 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
@@ -40,27 +41,29 @@ class local_recompletion_external extends external_api {
 
     /**
      * Describes the parameters for reset_course
+     *
      * @return external_function_parameters
      */
     public static function reset_course_parameters() {
         return new external_function_parameters(
-            [
-                'courseid' => new external_value(PARAM_INT, 'course id'),
-                'userid' => new external_value(PARAM_INT, 'userid')
-            ]
+                [
+                        'courseid' => new external_value(PARAM_INT, 'course id'),
+                        'userid' => new external_value(PARAM_INT, 'userid'),
+                ]
         );
     }
 
     /**
      * Resets course completion for the requested course id and user id
+     *
      * @param int $courseid
      * @param int $userid
      * @return array of errors and status result
      */
     public static function reset_course($courseid, $userid) {
         $params = self::validate_parameters(self::reset_course_parameters(), [
-            'courseid' => $courseid,
-            'userid' => $userid
+                'courseid' => $courseid,
+                'userid' => $userid,
         ]);
 
         $course = get_course($params['courseid']);
@@ -86,10 +89,10 @@ class local_recompletion_external extends external_api {
      */
     public static function reset_course_returns() {
         return new external_single_structure(
-            [
-                'status' => new external_value(PARAM_BOOL, 'status: true if success'),
-                'errors' => new external_value(PARAM_TEXT, 'errors'),
-            ]
+                [
+                        'status' => new external_value(PARAM_BOOL, 'status: true if success'),
+                        'errors' => new external_value(PARAM_TEXT, 'errors'),
+                ]
         );
     }
 }

--- a/lang/en/local_recompletion.php
+++ b/lang/en/local_recompletion.php
@@ -22,113 +22,161 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-$string['pluginname'] = 'Course recompletion';
-$string['recompletion'] = 'recompletion';
-$string['editrecompletion'] = 'Edit course recompletion settings';
-$string['recompletiontype:period'] = 'Period';
-$string['recompletiontype:schedule'] = 'Schedule';
-$string['recompletiontype:ondemand'] = 'On demand';
-$string['recompletiontype:disabled'] = 'Disabled';
-$string['recompletiontype'] = 'Recompletion type';
-$string['recompletiontype_help'] = 'Determines how user completion results will be reset for new courses.
-
-* Disabled - disables this feature.
-* Period - Allows a recompletion period (eg every 60 days) based on the users last course completion date.
-* On demand - Allow teacher to manually reset individual users as required.
-* Schedule - allows recompletion on a specified date eg 1st Jan every year.';
-$string['recompletionschedule'] = 'Recompletion schedule';
-$string['recompletionschedule_help'] = 'Set a date (e.g. Jan 1st) when completion results are reset. This date is calculated forwards from when a recompletion is last run. This reset would then occur at an interval. \'Jan 1\' will result in a yearly recompletion, \'friday\' will result in recompletion being run every Friday.';
-$string['recompletionschedulestart'] = 'Recompletion schedule start time';
-$string['recompletionschedulestart_help'] = 'This is to be used in combination with a schedule that is a time period instead of a set day (e.g. \'3 months\'). If selected, the first recompletion will happen on this day and will then use the recompletion schedule. This date must be a current or future date.';
-$string['recompletioncalculateddate'] = 'Next recompletion date: {$a}';
-$string['recompletionrange'] = 'Recompletion period';
-$string['recompletionrange_help'] = 'Set the period of time before a users completion results are reset.';
-$string['recompletionsettingssaved'] = 'Recompletion settings saved';
-$string['recompletion:manage'] = 'Allow course recompletion settings to be changed';
-$string['recompletion:bulkoperations'] = 'Bulk operations';
-$string['recompletion:resetmycompletion'] = 'Reset my own completion';
-$string['resetmycompletion'] = 'Reset my activity completion';
-$string['recompletiontask'] = 'Check for users that need to recomplete';
-$string['completionnotenabled'] = 'Completion is not enabled in this course';
-$string['recompletionnotenabledincourse'] = 'Recompletion is not enabled in courseid: {$a}';
-
-$string['recompletionnotify:completed'] = 'Send to completed users';
-$string['recompletionnotify:enrolled'] = 'Send to completed users with an enrollment';
-$string['recompletionnotify:activeenrolled'] = 'Send to completed users with an active enrollment';
-$string['recompletionnotify'] = 'Recompletion message';
-$string['recompletionnotify_help'] = 'Determines which users are notified of recompletion.
-* Send to completed users - If a course completion record exists for a user, they will be notified.
-* Send to completed users with an active enrollment - If a user has an active enrollment they will be notified.
-* Send to completed users with an enrollment - If a user has an active or suspended enrollment they will be notified.';
-
-$string['recompletionemailsubject'] = 'Recompletion message subject';
-$string['recompletionemailsubject_help'] = 'A custom recompletion email subject may be added as plain text
-
-The following placeholders may be included in the message:
-
-* Course name {$a->coursename}
-* User fullname {$a->fullname}';
-$string['recompletionemaildefaultsubject'] = 'Course {$a->coursename} recompletion required';
-$string['recompletionemailbody'] = 'Recompletion message body';
-$string['recompletionemailbody_help'] = 'A custom recompletion email subject may be added as plain text or Moodle-auto format, including HTML tags and multi-lang tags
-
-The following placeholders may be included in the message:
-
-* Course name {$a->coursename}
-* Link to course {$a->link}
-* Link to user\'s profile page {$a->profileurl}
-* User email {$a->email}
-* User fullname {$a->fullname}';
-$string['recompletionemaildefaultbody'] = 'Hi there, please recomplete the course {$a->coursename} {$a->link}';
+$string['abandoned'] = 'Abandoned';
 $string['advancedrecompletiontitle'] = 'Advanced';
-$string['deletegradedata'] = 'Delete all grades for the user';
-$string['deletegradedata_help'] = 'Delete current grade completion data from grade_grades table. Grade recompletion data is permanently deleted but data retained in Grade history data table.';
+$string['archive'] = 'Archive old attempts';
+$string['archivecertificate'] = 'Archive issued certificates (mod_certificate)';
+$string['archivecertificate_help'] = 'Should issued certificates be archived?';
+$string['archivechoice'] = "Archive old choice attempts";
 $string['archivecompletiondata'] = 'Archive completion data';
-$string['archivecompletiondata_help'] = 'Writes completion data to the local_recompletion_cc, local_recompletion_cc_cc and local_recompletion_cmc tables. Completion data will be permanently deleted if this is not selected.';
-$string['forcearchivecompletiondata'] = 'Force archive completion data';
-$string['forcearchivecompletiondata_help'] = 'If enabled, completion data archiving will be forced on for all course recompletions. This can prevent accidental data loss.';
-$string['emailrecompletiontitle'] = 'Custom recompletion message settings';
-$string['eventrecompletion'] = 'Course recompletion';
+$string['archivecompletiondata_help'] =
+        'Writes completion data to the local_recompletion_cc, local_recompletion_cc_cc and local_recompletion_cmc tables. Completion data will be permanently deleted if this is not selected.';
+$string['archivecoursecertificate'] = 'Archive issued certificates (mod_coursecertificate)';
+$string['archivecoursecertificate_help'] =
+        'Should issued certificates be archived? Archived certificates will remain in tool_certificate_issues table, but will have archived status.';
+$string['archivecustomcertcertificates'] = 'Archive issued custom certificates (mod_customcert)';
+$string['archivecustomcertcertificates_help'] = 'Should issued custom certificates be archived?';
+$string['archiveh5p'] = 'Archive old H5P attempts (mod_h5pactivity)';
+$string['archivehotpot'] = 'Archive old hotpot attempts';
+$string['archivehvp'] = 'Archive old H5P attempts (mod_hvp)';
+$string['archivelesson'] = 'Archive old Lesson attempts';
+$string['archivequestionnaire'] = 'Archive old questionnaire attempts';
+$string['archivequiz'] = 'Archive old quiz attempts';
+$string['archivescorm'] = 'Archive old SCORM attempts';
 $string['assignattempts'] = 'Assign attempts';
 $string['assignattempts_help'] = 'How to handle assignment attempts within the course.
 If the setting \'Update on grade change\' is used, when a teacher updates the grade inside an assignment activity and the user has already completed the course, their course completion date will be updated to use the date of the assignment grade change.';
-$string['extraattempt'] = 'Give student extra attempt/s';
-$string['quizattempts'] = 'Quiz attempts';
-$string['quizattempts_help'] = 'What to do with existing Quiz attempts. If delete and archive is selected, the old quiz attempts will be archived in the local_recompletion tables,
- if set to give extra attempts this will add a quiz override to allow the user to have the maximum number of allowed attempts set.';
-$string['questionnaireattempts'] = 'Questionnaire attempts';
-$string['questionnaireattempts_help'] = 'What to do with existing Questionnaire attempts. If delete and archive is selected, the old Questionnaire attempts will be archived in the local_recompletion tables.';
-$string['scormattempts'] = 'SCORM attempts';
-$string['scormattempts_help'] = 'Should existing SCORM attempts be deleted - if archive is selected, the old SCORM attempts will be archived in the local_recompletion_sst table.';
-$string['archive'] = 'Archive old attempts';
+$string['assignevent'] = 'Update course completion on grade change';
+$string['bulkchangedate'] = 'Change completion date for selected users';
+$string['bulkresetallcompletion'] = 'Reset all completion for selected users';
+$string['certificate'] = 'Certificates (mod_certificate)';
+$string['certificate_help'] = 'Should issued certificates be deleted?';
+$string['certificateverifywarn'] =
+        'Attention: Deleting the issued certificates without archiving will result in the fact that issued certificates cannot be verified anymore in Moodle. Please only delete the certificates if this is acceptable for you.';
+$string['choiceattempts'] = "Choice attempts";
+$string['choiceattempts_help'] =
+        'Should existing Choice attempts be deleted - if archive is selected, the old Choice attempts will be archived in the local_recompletion_cha table.';
+$string['completed'] = 'Completed';
+$string['completionnotenabled'] = 'Completion is not enabled in this course';
+$string['completionreset'] = 'Completion for the selected students in this course has been reset.';
+$string['completionresetuser'] = 'Completion for {$a} in this course has been reset.';
+$string['completionupdated'] = 'Course completion dates were updated';
+$string['coursecertificate'] = 'Certificates (mod_coursecertificate)';
+$string['coursecertificate_help'] = 'Should issued certificates be deleted?';
+$string['coursecertificateverifywarn'] =
+        'Attention: Deleting the issued certificates without archiving will result in the fact that issued certificates cannot be verified anymore in Moodle. Please only delete the certificates if this is acceptable for you.';
+$string['coursecompletiondate'] = 'New course completion date';
+$string['customcertcertificates'] = 'Custom certificates (mod_customcert)';
+$string['customcertcertificates_help'] = 'Should issued custom certificates be deleted?';
+$string['customcertresetcertificates'] = 'Delete issued certificates';
+$string['customcertresetcertificatesverifywarn'] =
+        'Attention: Deleting the issued certificates, even if you archive them before the deletion, will result in the fact that issues certificates cannot be verified anymore in Moodle. Please only delete the certificates if this is acceptable for you.';
+$string['datasource:local_recompletion_cc'] = 'Archive of course completions';
+$string['datasource:local_recompletion_ccert_is'] = 'Archive of issued certificates (mod_customcert)';
+$string['datasource:local_recompletion_cert'] = 'Archive of issued certificates (mod_certificate)';
+$string['datasource:local_recompletion_cmc'] = 'Archive of activity completions';
+$string['datasource:local_recompletion_h5p'] = 'Archive of H5P attempts (mod_h5pactivity)';
+$string['datasource:local_recompletion_hpa'] = 'Archive of hotpot attempts';
+$string['datasource:local_recompletion_lg'] = 'Archive of lesson grades';
+$string['datasource:local_recompletion_qa'] = 'Archive of quiz attempts';
+$string['datasource:local_recompletion_qg'] = 'Archive of quiz grades';
+$string['defaultsettings'] = 'Recompletion default settings';
 $string['delete'] = 'Delete existing attempts';
+$string['deletecertificate'] = 'Delete issued certificates';
+$string['deletecoursecertificate'] = 'Delete issued certificates';
+$string['deletegradedata'] = 'Delete all grades for the user';
+$string['deletegradedata_help'] =
+        'Delete current grade completion data from grade_grades table. Grade recompletion data is permanently deleted but data retained in Grade history data table.';
 $string['donothing'] = 'Do nothing';
-$string['resetcompletionconfirm'] = 'Are you sure you want to reset all completion data in this course for {$a}?  Warning - this may permanently delete some submitted content.';
+$string['editcompletion'] = 'Edit course completion date';
+$string['editcompletion_desc'] = 'Modify the course completion date for the following users:';
+$string['editrecompletion'] = 'Edit course recompletion settings';
+$string['emailrecompletiontitle'] = 'Custom recompletion message settings';
+$string['endtime'] = 'End time';
+$string['entity:local_recompletion_cc'] = 'Archive of course completions';
+$string['entity:local_recompletion_ccert_is'] = 'Archive of issued certificates (mod_customcert)';
+$string['entity:local_recompletion_cert'] = 'Archive of issued certificates (mod_certificate)';
+$string['entity:local_recompletion_cmc'] = 'Archive of activity completions';
+$string['entity:local_recompletion_h5p'] = 'Archive of H5P attempts (mod_h5pactivity)';
+$string['entity:local_recompletion_hpa'] = 'Archive of hotpot attempts';
+$string['entity:local_recompletion_lg'] = 'Archive of lesson grades';
+$string['entity:local_recompletion_qa'] = 'Archive of quiz attempts';
+$string['entity:local_recompletion_qg'] = 'Archive of quiz grades';
+$string['eventrecompletion'] = 'Course recompletion';
+$string['extraattempt'] = 'Give student extra attempt/s';
+$string['forcearchivecompletiondata'] = 'Force archive completion data';
+$string['forcearchivecompletiondata_help'] =
+        'If enabled, completion data archiving will be forced on for all course recompletions. This can prevent accidental data loss.';
+$string['h5pattempts'] = 'H5P attempts (mod_h5pactivity)';
+$string['h5pattempts_help'] =
+        'How to handle H5P attempts within the course. If archive is selected, the old H5P attempts will be archived in the local_recompletion_h5p and local_recompletion_h5pr tables.';
+$string['hotpotattempts'] = 'Hotpot attempts';
+$string['hotpotattempts_help'] =
+        'How to handle hotpot attempts within the course. If archive is selected, the attempts will be archived.';
+$string['hvpattempts'] = 'H5P attempts (mod_hvp)';
+$string['hvpattempts_help'] =
+        'How to handle H5P attempts within the course. If archive is selected, the old H5P attempts will be archived in the local_recompletion_hvp table.';
+$string['inprogress'] = 'In progress';
+$string['invalidscheduledate'] = 'Invalid schedule date entered.';
+$string['invalidschedulestartdate'] = 'Invalid schedule start date entered, this must be a future or current date.';
+$string['lessonattempts'] = 'Lesson attempts';
+$string['lessonattempts_help'] =
+        'How to handle Lesson attempts within the course. If archive is selected, the attempts will be archived.';
+$string['modifycompletiondates'] = 'Modify course completion dates';
+$string['noassigngradepermission'] =
+        'Your completion was reset, but this course contains an assignment that could not be reset, please ask your teacher to do this for you if required.';
+$string['nousersselected'] = 'No users were selected';
+$string['penalties'] = 'Penalties';
+$string['pluginname'] = 'Course recompletion';
+$string['pluginssettings'] = 'Plugins settings';
+$string['privacy:metadata:attempt'] = 'The attempt number';
+$string['privacy:metadata:completionstate'] = 'If the activity has been completed';
+$string['privacy:metadata:correct'] = 'Correct answer?';
+$string['privacy:metadata:course'] = 'The course ID linked to this table.';
+$string['privacy:metadata:coursemoduleid'] = 'The activity ID';
+$string['privacy:metadata:coursesummary'] = 'Stores the course completion data for a user.';
+$string['privacy:metadata:deadline'] = 'Deadline';
+$string['privacy:metadata:endtime'] = 'End time';
+$string['privacy:metadata:flag'] = 'Flag';
+$string['privacy:metadata:grade'] = 'Grade';
+$string['privacy:metadata:gradefinal'] = 'Final grade received for course completion';
+$string['privacy:metadata:lessontime'] = 'Lesson duration';
 $string['privacy:metadata:local_recompletion_cc'] = 'Archive of previous course completions.';
 $string['privacy:metadata:local_recompletion_cc_cc'] = 'Archive of previous course_completion_crit_compl.';
 $string['privacy:metadata:local_recompletion_ccert_is'] = 'Archive of previous course customcert issues.';
+$string['privacy:metadata:local_recompletion_ccert_is:emailed'] = 'If the customcert issue was emailed.';
+$string['privacy:metadata:local_recompletion_ccert_is:timecreated'] = 'The time that the customcert issue created';
+$string['privacy:metadata:local_recompletion_cert'] = 'Archive of previous certificate issues.';
+$string['privacy:metadata:local_recompletion_cert:timecreated'] = 'The time that the certificate issue created';
 $string['privacy:metadata:local_recompletion_cha'] = 'Archive of choice answers';
 $string['privacy:metadata:local_recompletion_cha:choiceid'] = 'The Choice ID of the Archive of choice answers';
 $string['privacy:metadata:local_recompletion_cha:optionid'] = 'The Option ID of the Archive of choice answers';
 $string['privacy:metadata:local_recompletion_cmc'] = 'Archive of previous course module completions.';
 $string['privacy:metadata:local_recompletion_cmv'] = 'Archive of previous course module views.';
+$string['privacy:metadata:local_recompletion_h5p'] = 'Archive for H5P (mod_h5pactivity) attempt tracking information.';
+$string['privacy:metadata:local_recompletion_h5pr'] = 'Archive for H5P (mod_h5pactivity) attempt results tracking information.';
+$string['privacy:metadata:local_recompletion_hpa'] = 'Archive for hotpot attempts.';
+$string['privacy:metadata:local_recompletion_hvp'] = 'Archive for H5P (mod_hvp) user data.';
+$string['privacy:metadata:local_recompletion_hvp:data'] = 'The actual user data that was stored.';
+$string['privacy:metadata:local_recompletion_hvp:hvp_id'] = 'Id of hvp content';
+$string['privacy:metadata:local_recompletion_la'] = 'Archive for lesson_attempts';
+$string['privacy:metadata:local_recompletion_lb'] = 'Archive of lesson_branch';
+$string['privacy:metadata:local_recompletion_lg'] = 'Archive of lesson_grades';
+$string['privacy:metadata:local_recompletion_lo'] = 'Archive of lesson_overrides';
+$string['privacy:metadata:local_recompletion_lt'] = 'Archive of lesson_timer';
+$string['privacy:metadata:local_recompletion_ltia'] = 'User access log and gradeback data.';
 $string['privacy:metadata:local_recompletion_ltia:lastaccess'] = 'The time when the user last accessed the course.';
 $string['privacy:metadata:local_recompletion_ltia:lastgrade'] = 'The last grade the user was recorded of having.';
 $string['privacy:metadata:local_recompletion_ltia:timecreated'] = 'The time when the user was enrolled.';
 $string['privacy:metadata:local_recompletion_ltia:toolid'] = 'The ID of the tool of LTI enrolment method.';
-$string['privacy:metadata:local_recompletion_ltia'] = 'User access log and gradeback data.';
 $string['privacy:metadata:local_recompletion_ltia:userid'] = 'The ID of the user.';
-$string['privacy:metadata:userid'] = 'The user ID linked to this table.';
-$string['privacy:metadata:course'] = 'The course ID linked to this table.';
-$string['privacy:metadata:timecompleted'] = 'The time that the course was completed.';
-$string['privacy:metadata:timeenrolled'] = 'The time that the user was enrolled in the course';
-$string['privacy:metadata:timemodified'] = 'The time that the record was modified';
-$string['privacy:metadata:timestarted'] = 'The time the course was started.';
-$string['privacy:metadata:coursesummary'] = 'Stores the course completion data for a user.';
-$string['privacy:metadata:gradefinal'] = 'Final grade received for course completion';
+$string['privacy:metadata:local_recompletion_qr'] = 'Recompletion Questionnaire response table';
+$string['privacy:metadata:local_recompletion_qr:complete'] = 'complete';
+$string['privacy:metadata:local_recompletion_qr:grade'] = 'Grade';
+$string['privacy:metadata:local_recompletion_qr:questionnaireid'] = 'Questionnaire id';
+$string['privacy:metadata:local_recompletion_qr:submitted'] = 'Submitted';
+$string['privacy:metadata:maxattempts'] = 'Max number of attempts';
 $string['privacy:metadata:overrideby'] = 'The user ID of the person who overrode the activity completion';
-$string['privacy:metadata:reaggregate'] = 'If the course completion was reaggregated.';
-$string['privacy:metadata:unenroled'] = 'If the user has been unenrolled from the course';
 $string['privacy:metadata:quiz_attempts'] = 'Archived details about each attempt on a quiz.';
 $string['privacy:metadata:quiz_attempts:attempt'] = 'The attempt number.';
 $string['privacy:metadata:quiz_attempts:currentpage'] = 'The current page that the user is on.';
@@ -145,148 +193,117 @@ $string['privacy:metadata:quiz_grades:grade'] = 'The overall grade for this quiz
 $string['privacy:metadata:quiz_grades:quiz'] = 'The quiz that was graded.';
 $string['privacy:metadata:quiz_grades:timemodified'] = 'The time that the grade was modified.';
 $string['privacy:metadata:quiz_grades:userid'] = 'The user who was graded.';
+$string['privacy:metadata:rawscore'] = 'The score obtained';
+$string['privacy:metadata:reaggregate'] = 'If the course completion was reaggregated.';
+$string['privacy:metadata:retake'] = 'Retake';
 $string['privacy:metadata:scoes_value:element'] = 'The ID of the element to be tracked';
 $string['privacy:metadata:scoes_value:value'] = 'The value of the given element';
-$string['privacy:metadata:coursemoduleid'] = 'The activity ID';
-$string['privacy:metadata:completionstate'] = 'If the activity has been completed';
-$string['privacy:metadata:viewed'] = 'If the activity was viewed';
-$string['privacy:metadata:attempt'] = 'The attempt number';
+$string['privacy:metadata:score'] = 'Score';
 $string['privacy:metadata:scorm_attempt'] = 'Archive of previous SCORM attempts.';
 $string['privacy:metadata:scorm_scoes_value'] = 'Archive of the tracked data of the SCOes belonging to the activity';
-$string['privacy:metadata:local_recompletion_qr:questionnaireid'] = 'Questionnaire id';
-$string['privacy:metadata:local_recompletion_qr:submitted'] = 'Submitted';
-$string['privacy:metadata:local_recompletion_qr:complete'] = 'complete';
-$string['privacy:metadata:local_recompletion_qr:grade'] = 'Grade';
-$string['privacy:metadata:local_recompletion_qr'] = 'Recompletion Questionnaire response table';
-$string['privacy:metadata:local_recompletion_ccert_is:emailed'] = 'If the customcert issue was emailed.';
-$string['privacy:metadata:local_recompletion_ccert_is:timecreated'] = 'The time that the customcert issue created';
-$string['privacy:metadata:local_recompletion_hvp'] = 'Archive for H5P (mod_hvp) user data.';
-$string['privacy:metadata:local_recompletion_hvp:hvp_id'] = 'Id of hvp content';
-$string['privacy:metadata:local_recompletion_hvp:data'] = 'The actual user data that was stored.';
-$string['privacy:metadata:local_recompletion_h5p'] = 'Archive for H5P (mod_h5pactivity) attempt tracking information.';
-$string['privacy:metadata:local_recompletion_h5pr'] = 'Archive for H5P (mod_h5pactivity) attempt results tracking information.';
-$string['privacy:metadata:local_recompletion_hpa'] = 'Archive for hotpot attempts.';
-$string['privacy:metadata:attempt'] = 'The attempt number';
-$string['privacy:metadata:rawscore'] = 'The score obtained';
-$string['privacy:metadata:timecreated'] = 'The time when the tracked element was created';
-$string['privacy:metadata:timemodified'] = 'The last time element was tracked';
-$string['privacy:metadata:local_recompletion_la'] = 'Archive for lesson_attempts';
-$string['privacy:metadata:correct'] = 'Correct answer?';
-$string['privacy:metadata:useranswer'] = 'Answer';
-$string['privacy:metadata:local_recompletion_lg'] = 'Archive of lesson_grades';
-$string['privacy:metadata:grade'] = 'Grade';
-$string['privacy:metadata:local_recompletion_lt'] = 'Archive of lesson_timer';
-$string['privacy:metadata:starttime'] = 'Start time';
-$string['privacy:metadata:endtime'] = 'End time';
-$string['privacy:metadata:lessontime'] = 'Lesson duration';
-$string['privacy:metadata:local_recompletion_lb'] = 'Archive of lesson_branch';
-$string['privacy:metadata:flag'] = 'Flag';
-$string['privacy:metadata:local_recompletion_lo'] = 'Archive of lesson_overrides';
-$string['privacy:metadata:deadline'] = 'Deadline';
-$string['privacy:metadata:maxattempts'] = 'Max number of attempts';
-$string['privacy:metadata:retake'] = 'Retake';
-$string['privacy:metadata:score'] = 'Score';
 $string['privacy:metadata:scormid'] = 'Scorm id';
-$string['privacy:metadata:local_recompletion_cert'] = 'Archive of previous certificate issues.';
-$string['privacy:metadata:local_recompletion_cert:timecreated'] = 'The time that the certificate issue created';
-$string['noassigngradepermission'] = 'Your completion was reset, but this course contains an assignment that could not be reset, please ask your teacher to do this for you if required.';
-$string['editcompletion'] = 'Edit course completion date';
-$string['editcompletion_desc'] = 'Modify the course completion date for the following users:';
-$string['coursecompletiondate'] = 'New course completion date';
-$string['completionupdated'] = 'Course completion dates were updated';
-$string['bulkchangedate'] = 'Change completion date for selected users';
-$string['nousersselected'] = 'No users were selected';
+$string['privacy:metadata:starttime'] = 'Start time';
+$string['privacy:metadata:timecompleted'] = 'The time that the course was completed.';
+$string['privacy:metadata:timecreated'] = 'The time when the tracked element was created';
+$string['privacy:metadata:timeenrolled'] = 'The time that the user was enrolled in the course';
+$string['privacy:metadata:timemodified'] = 'The last time element was tracked';
+$string['privacy:metadata:timestarted'] = 'The time the course was started.';
+$string['privacy:metadata:unenroled'] = 'If the user has been unenrolled from the course';
+$string['privacy:metadata:useranswer'] = 'Answer';
+$string['privacy:metadata:userid'] = 'The user ID linked to this table.';
+$string['privacy:metadata:viewed'] = 'If the activity was viewed';
+$string['pulsenotifications'] = 'Pulse notifications';
+$string['pulsenotifications_help'] = 'Should Pulse notifications which have already been sent be reset?';
+$string['pulseresetnotifications'] = 'Reset notifications';
+$string['questionnaireattempts'] = 'Questionnaire attempts';
+$string['questionnaireattempts_help'] =
+        'What to do with existing Questionnaire attempts. If delete and archive is selected, the old Questionnaire attempts will be archived in the local_recompletion tables.';
+$string['quizattempts'] = 'Quiz attempts';
+$string['quizattempts_help'] = 'What to do with existing Quiz attempts. If delete and archive is selected, the old quiz attempts will be archived in the local_recompletion tables,
+ if set to give extra attempts this will add a quiz override to allow the user to have the maximum number of allowed attempts set.';
+$string['recompletion'] = 'recompletion';
+$string['recompletion:bulkoperations'] = 'Bulk operations';
+$string['recompletion:manage'] = 'Allow course recompletion settings to be changed';
+$string['recompletion:resetmycompletion'] = 'Reset my own completion';
+$string['recompletioncalculateddate'] = 'Next recompletion date: {$a}';
+$string['recompletionemailbody'] = 'Recompletion message body';
+$string['recompletionemailbody_help'] = 'A custom recompletion email subject may be added as plain text or Moodle-auto format, including HTML tags and multi-lang tags
+
+The following placeholders may be included in the message:
+
+* Course name {$a->coursename}
+* Link to course {$a->link}
+* Link to user\'s profile page {$a->profileurl}
+* User email {$a->email}
+* User fullname {$a->fullname}';
+$string['recompletionemaildefaultbody'] = 'Hi there, please recomplete the course {$a->coursename} {$a->link}';
+$string['recompletionemaildefaultsubject'] = 'Course {$a->coursename} recompletion required';
+
+$string['recompletionemailsubject'] = 'Recompletion message subject';
+$string['recompletionemailsubject_help'] = 'A custom recompletion email subject may be added as plain text
+
+The following placeholders may be included in the message:
+
+* Course name {$a->coursename}
+* User fullname {$a->fullname}';
+$string['recompletionnotenabledincourse'] = 'Recompletion is not enabled in courseid: {$a}';
+$string['recompletionnotify'] = 'Recompletion message';
+$string['recompletionnotify:activeenrolled'] = 'Send to completed users with an active enrollment';
+
+$string['recompletionnotify:completed'] = 'Send to completed users';
+$string['recompletionnotify:enrolled'] = 'Send to completed users with an enrollment';
+$string['recompletionnotify_help'] = 'Determines which users are notified of recompletion.
+* Send to completed users - If a course completion record exists for a user, they will be notified.
+* Send to completed users with an active enrollment - If a user has an active enrollment they will be notified.
+* Send to completed users with an enrollment - If a user has an active or suspended enrollment they will be notified.';
+$string['recompletionrange'] = 'Recompletion period';
+$string['recompletionrange_help'] = 'Set the period of time before a users completion results are reset.';
+$string['recompletionschedule'] = 'Recompletion schedule';
+$string['recompletionschedule_help'] =
+        'Set a date (e.g. Jan 1st) when completion results are reset. This date is calculated forwards from when a recompletion is last run. This reset would then occur at an interval. \'Jan 1\' will result in a yearly recompletion, \'friday\' will result in recompletion being run every Friday.';
+$string['recompletionschedulestart'] = 'Recompletion schedule start time';
+$string['recompletionschedulestart_help'] =
+        'This is to be used in combination with a schedule that is a time period instead of a set day (e.g. \'3 months\'). If selected, the first recompletion will happen on this day and will then use the recompletion schedule. This date must be a current or future date.';
+$string['recompletionsettingssaved'] = 'Recompletion settings saved';
+$string['recompletiontask'] = 'Check for users that need to recomplete';
+$string['recompletiontype'] = 'Recompletion type';
+$string['recompletiontype:disabled'] = 'Disabled';
+$string['recompletiontype:ondemand'] = 'On demand';
+$string['recompletiontype:period'] = 'Period';
+$string['recompletiontype:schedule'] = 'Schedule';
+$string['recompletiontype_help'] = 'Determines how user completion results will be reset for new courses.
+
+* Disabled - disables this feature.
+* Period - Allows a recompletion period (eg every 60 days) based on the users last course completion date.
+* On demand - Allow teacher to manually reset individual users as required.
+* Schedule - allows recompletion on a specified date eg 1st Jan every year.';
+$string['recompletionunenrolenable'] = 'Reset completion on un-enrolment';
+$string['recompletionunenrolenable_help'] = 'Enable to trigger completion reset on user un-enrolment';
 $string['resetallcompletion'] = 'Reset all completion';
-$string['bulkresetallcompletion'] = 'Reset all completion for selected users';
+$string['resetcompletionconfirm'] =
+        'Are you sure you want to reset all completion data in this course for {$a}?  Warning - this may permanently delete some submitted content.';
 $string['resetcompletionfor'] = 'Reset completion for {$a}';
-$string['completionresetuser'] = 'Completion for {$a} in this course has been reset.';
-$string['completionreset'] = 'Completion for the selected students in this course has been reset.';
-$string['modifycompletiondates'] = 'Modify course completion dates';
-$string['assignevent'] = 'Update course completion on grade change';
-$string['defaultsettings'] = 'Recompletion default settings';
-$string['archivequiz'] = 'Archive old quiz attempts';
-$string['resetquizoverride'] = 'Reset quiz user overrides';
-$string['archivequestionnaire'] = 'Archive old questionnaire attempts';
-$string['archivescorm'] = 'Archive old SCORM attempts';
 $string['resetlti'] = 'Reset LTI grades';
 $string['resetltis'] = 'LTI grades';
 $string['resetltis_help'] = 'How to handle LTI grades within the course.
 If the setting \'Reset LTI grades\' is used, all grade LTI results will be reset to 0.
 When user achieved new completion in the course, the updated course grade will be resend to the LTI provider.';
-$string['pulsenotifications'] = 'Pulse notifications';
-$string['pulsenotifications_help'] = 'Should Pulse notifications which have already been sent be reset?';
-$string['pulseresetnotifications'] = 'Reset notifications';
-$string['choiceattempts'] = "Choice attempts";
-$string['archivechoice'] = "Archive old choice attempts";
-$string['choiceattempts_help'] = 'Should existing Choice attempts be deleted - if archive is selected, the old Choice attempts will be archived in the local_recompletion_cha table.';
-$string['customcertcertificates'] = 'Custom certificates (mod_customcert)';
-$string['customcertcertificates_help'] = 'Should issued custom certificates be deleted?';
-$string['customcertresetcertificates'] = 'Delete issued certificates';
-$string['customcertresetcertificatesverifywarn'] = 'Attention: Deleting the issued certificates, even if you archive them before the deletion, will result in the fact that issues certificates cannot be verified anymore in Moodle. Please only delete the certificates if this is acceptable for you.';
-$string['archivecustomcertcertificates'] = 'Archive issued custom certificates (mod_customcert)';
-$string['archivecustomcertcertificates_help'] = 'Should issued custom certificates be archived?';
-$string['recompletionunenrolenable'] = 'Reset completion on un-enrolment';
-$string['recompletionunenrolenable_help'] = 'Enable to trigger completion reset on user un-enrolment';
-$string['hvpattempts'] = 'H5P attempts (mod_hvp)';
-$string['hvpattempts_help'] = 'How to handle H5P attempts within the course. If archive is selected, the old H5P attempts will be archived in the local_recompletion_hvp table.';
-$string['archivehvp'] = 'Archive old H5P attempts (mod_hvp)';
-$string['h5pattempts'] = 'H5P attempts (mod_h5pactivity)';
-$string['h5pattempts_help'] = 'How to handle H5P attempts within the course. If archive is selected, the old H5P attempts will be archived in the local_recompletion_h5p and local_recompletion_h5pr tables.';
-$string['archiveh5p'] = 'Archive old H5P attempts (mod_h5pactivity)';
-$string['pluginssettings'] = 'Plugins settings';
-$string['restrictionsettings'] = 'Restrictions settings';
-$string['restrictenrol'] = 'Enrol method';
-$string['restrictenrol_help'] = 'Ony users enrolled with selected enrol methods will be included in resetting completion data. If none selected, that means no restrictions on enrolment method for users.';
-$string['restrictionsheader'] = 'Restrictions';
+$string['resetmycompletion'] = 'Reset my activity completion';
+$string['resetquizoverride'] = 'Reset quiz user overrides';
 $string['restricted'] = 'Resetting completion for a given user is restricted';
 $string['restrictedbyenrol'] = 'Resetting completion for a given user is restricted by enrolment method';
-$string['entity:local_recompletion_cc'] = 'Archive of course completions';
-$string['datasource:local_recompletion_cc'] = 'Archive of course completions';
-$string['entity:local_recompletion_cmc'] = 'Archive of activity completions';
-$string['datasource:local_recompletion_cmc'] = 'Archive of activity completions';
-$string['timecreated'] = 'Time created';
-$string['timemodified'] = 'Time modified';
-$string['status'] = 'Completion status';
-$string['entity:local_recompletion_qg'] = 'Archive of quiz grades';
-$string['datasource:local_recompletion_qg'] = 'Archive of quiz grades';
-$string['entity:local_recompletion_qa'] = 'Archive of quiz attempts';
-$string['datasource:local_recompletion_qa'] = 'Archive of quiz attempts';
-$string['entity:local_recompletion_h5p'] = 'Archive of H5P attempts (mod_h5pactivity)';
-$string['datasource:local_recompletion_h5p'] = 'Archive of H5P attempts (mod_h5pactivity)';
-$string['yearly'] = 'Yearly';
-$string['invalidscheduledate'] = 'Invalid schedule date entered.';
-$string['invalidschedulestartdate'] = 'Invalid schedule start date entered, this must be a future or current date.';
-$string['lessonattempts'] = 'Lesson attempts';
-$string['lessonattempts_help'] = 'How to handle Lesson attempts within the course. If archive is selected, the attempts will be archived.';
-$string['archivelesson'] = 'Archive old Lesson attempts';
-$string['entity:local_recompletion_lg'] = 'Archive of lesson grades';
-$string['datasource:local_recompletion_lg'] = 'Archive of lesson grades';
-$string['hotpotattempts'] = 'Hotpot attempts';
-$string['hotpotattempts_help'] = 'How to handle hotpot attempts within the course. If archive is selected, the attempts will be archived.';
-$string['archivehotpot'] = 'Archive old hotpot attempts';
-$string['entity:local_recompletion_hpa'] = 'Archive of hotpot attempts';
-$string['datasource:local_recompletion_hpa'] = 'Archive of hotpot attempts';
-$string['starttime'] = 'Start time';
-$string['endtime'] = 'End time';
+$string['restrictenrol'] = 'Enrol method';
+$string['restrictenrol_help'] =
+        'Ony users enrolled with selected enrol methods will be included in resetting completion data. If none selected, that means no restrictions on enrolment method for users.';
+$string['restrictionsettings'] = 'Restrictions settings';
+$string['restrictionsheader'] = 'Restrictions';
 $string['score'] = 'Score';
-$string['penalties'] = 'Penalties';
-$string['inprogress'] = 'In progress';
-$string['completed'] = 'Completed';
+$string['scormattempts'] = 'SCORM attempts';
+$string['scormattempts_help'] =
+        'Should existing SCORM attempts be deleted - if archive is selected, the old SCORM attempts will be archived in the local_recompletion_sst table.';
+$string['starttime'] = 'Start time';
+$string['status'] = 'Completion status';
+$string['timecreated'] = 'Time created';
 $string['timedout'] = 'Timed out';
-$string['abandoned'] = 'Abandoned';
-$string['coursecertificate'] = 'Certificates (mod_coursecertificate)';
-$string['coursecertificate_help'] = 'Should issued certificates be deleted?';
-$string['deletecoursecertificate'] = 'Delete issued certificates';
-$string['coursecertificateverifywarn'] = 'Attention: Deleting the issued certificates without archiving will result in the fact that issued certificates cannot be verified anymore in Moodle. Please only delete the certificates if this is acceptable for you.';
-$string['archivecoursecertificate'] = 'Archive issued certificates (mod_coursecertificate)';
-$string['archivecoursecertificate_help'] = 'Should issued certificates be archived? Archived certificates will remain in tool_certificate_issues table, but will have archived status.';
-$string['certificate'] = 'Certificates (mod_certificate)';
-$string['certificate_help'] = 'Should issued certificates be deleted?';
-$string['deletecertificate'] = 'Delete issued certificates';
-$string['certificateverifywarn'] = 'Attention: Deleting the issued certificates without archiving will result in the fact that issued certificates cannot be verified anymore in Moodle. Please only delete the certificates if this is acceptable for you.';
-$string['archivecertificate'] = 'Archive issued certificates (mod_certificate)';
-$string['archivecertificate_help'] = 'Should issued certificates be archived?';
-$string['entity:local_recompletion_cert'] = 'Archive of issued certificates (mod_certificate)';
-$string['datasource:local_recompletion_cert'] = 'Archive of issued certificates (mod_certificate)';
-$string['entity:local_recompletion_ccert_is'] = 'Archive of issued certificates (mod_customcert)';
-$string['datasource:local_recompletion_ccert_is'] = 'Archive of issued certificates (mod_customcert)';
+$string['timemodified'] = 'Time modified';
+$string['yearly'] = 'Yearly';

--- a/lib.php
+++ b/lib.php
@@ -26,8 +26,8 @@
  * This function extends the navigation with the recompletion item
  *
  * @param navigation_node $navigation The navigation node to extend
- * @param stdClass        $course     The course to object for the tool
- * @param context         $context    The context of the course
+ * @param stdClass $course The course to object for the tool
+ * @param context $context The context of the course
  */
 function local_recompletion_extend_navigation_course($navigation, $course, $context) {
     global $DB;
@@ -39,18 +39,18 @@ function local_recompletion_extend_navigation_course($navigation, $course, $cont
     if (has_capability('local/recompletion:resetmycompletion', $context)) {
         $enabled = $DB->get_field('local_recompletion_config', 'value', ['name' => 'recompletiontype', 'course' => $course->id]);
         if (!empty($enabled)) {
-            $url = new moodle_url('/local/recompletion/resetcompletion.php', array('id' => $course->id));
+            $url = new moodle_url('/local/recompletion/resetcompletion.php', ['id' => $course->id]);
             $name = get_string('resetmycompletion', 'local_recompletion');
             $navigation->add($name, $url, navigation_node::TYPE_SETTING, null, null, new pix_icon('i/settings', ''));
         }
     }
 
     if (has_capability('local/recompletion:manage', $context)) {
-        $url = new moodle_url('/local/recompletion/recompletion.php', array('id' => $course->id));
+        $url = new moodle_url('/local/recompletion/recompletion.php', ['id' => $course->id]);
         $name = get_string('pluginname', 'local_recompletion');
         $navigation->add($name, $url, navigation_node::TYPE_SETTING, null, null, new pix_icon('i/settings', ''));
 
-        $url = new moodle_url('/local/recompletion/participants.php', array('id' => $course->id));
+        $url = new moodle_url('/local/recompletion/participants.php', ['id' => $course->id]);
         $name = get_string('modifycompletiondates', 'local_recompletion');
         $navigation->add($name, $url, navigation_node::TYPE_SETTING, null, null, new pix_icon('i/settings', ''));
 

--- a/locallib.php
+++ b/locallib.php
@@ -30,26 +30,27 @@ define('LOCAL_RECOMPLETION_NOTHING', 0);
 define('LOCAL_RECOMPLETION_DELETE', 1);
 define('LOCAL_RECOMPLETION_EXTRAATTEMPT', 2);
 
-require_once($CFG->dirroot.'/user/lib.php');
-require_once($CFG->libdir.'/formslib.php');
-require_once($CFG->dirroot.'/course/lib.php');
-require_once($CFG->libdir.'/completionlib.php');
-require_once($CFG->libdir.'/gradelib.php');
+require_once($CFG->dirroot . '/user/lib.php');
+require_once($CFG->libdir . '/formslib.php');
+require_once($CFG->dirroot . '/course/lib.php');
+require_once($CFG->libdir . '/completionlib.php');
+require_once($CFG->libdir . '/gradelib.php');
 require_once($CFG->dirroot . '/mod/assign/locallib.php');
 require_once($CFG->dirroot . '/mod/quiz/lib.php');
 
 /**
  * Get list of supported plugin classes.
+ *
  * @return array
  * @throws coding_exception
  */
 function local_recompletion_get_supported_plugins() {
     global $CFG;
     $plugins = [];
-    $files = scandir($CFG->dirroot. '/local/recompletion/classes/plugins');
+    $files = scandir($CFG->dirroot . '/local/recompletion/classes/plugins');
     foreach ($files as $file) {
         $component = clean_param(str_replace('.php', '', $file), PARAM_ALPHANUMEXT);
-        list($plugin, $type) = core_component::normalize_component($component);
+        [$plugin, $type] = core_component::normalize_component($component);
 
         if (!core_component::is_valid_plugin_name($type, $plugin)) {
             continue;
@@ -65,13 +66,14 @@ function local_recompletion_get_supported_plugins() {
 
 /**
  * Get list of supported restriction classes.
+ *
  * @return array
  */
 function local_recompletion_get_supported_restrictions(): array {
     global $CFG;
 
     $restrictions = [];
-    $files = scandir($CFG->dirroot. '/local/recompletion/classes/local/restrictions');
+    $files = scandir($CFG->dirroot . '/local/recompletion/classes/local/restrictions');
     foreach ($files as $file) {
         $class = clean_param(str_replace('.php', '', $file), PARAM_ALPHANUMEXT);
         if (!empty($class) && $class !== 'base') {
@@ -106,6 +108,7 @@ function local_recompletion_set_form_data($mformdata) {
 
 /**
  * Return the data that will be used upon saving.
+ *
  * @param string[] $data
  * @return array|false
  */
@@ -118,7 +121,7 @@ function local_recompletion_get_data(array $data) {
         $result['recompletionemailbody_format'] = FORMAT_HTML;
     }
     // Prepare email body for editor.
-    $emailbody = array('text' => $result['recompletionemailbody'], 'format' => $result['recompletionemailbody_format']);
+    $emailbody = ['text' => $result['recompletionemailbody'], 'format' => $result['recompletionemailbody_format']];
     $result['recompletionemailbody'] = $emailbody;
 
     return $result;
@@ -126,6 +129,7 @@ function local_recompletion_get_data(array $data) {
 
 /**
  * Update course completions
+ *
  * @param int $courseid
  * @param array[] $users
  * @param int $timecompleted
@@ -133,7 +137,7 @@ function local_recompletion_get_data(array $data) {
 function local_recompletion_update_course_completion(int $courseid, array $users, int $timecompleted) {
     foreach ($users as $user) {
         $params = ['userid' => $user, 'course' => $courseid];
-        $ccompletion = new \completion_completion($params);
+        $ccompletion = new completion_completion($params);
         if ($ccompletion->is_complete()) {
             // If we already have a completion date, clear it first so that mark_complete works.
             $ccompletion->timecompleted = null;
@@ -142,9 +146,9 @@ function local_recompletion_update_course_completion(int $courseid, array $users
     }
 }
 
-
 /**
  * Get local config
+ *
  * @param stdClass $course - course record.
  */
 function local_recompletion_get_config($course) {
@@ -152,23 +156,23 @@ function local_recompletion_get_config($course) {
     // Ideally this would be picked up directly from settings or the override form.
     // Values if not set in the form are set to 0.
     $defaultconfig = [
-        'recompletiontype' => '',
-        'recompletionduration' => 0,
-        'recompletionschedule' => '',
-        'assignevent' => null,
-        'archivecompletiondata' => 0,
-        'recompletionnotify' => '',
-        'recompletionunenrolenable' => 0,
-        'recompletionemailbody' => '',
-        'recompletionemailbody_format' => FORMAT_HTML,
-        'recompletionemailsubject' => '',
-        'deletegradedata' => 0,
-        'nextresettime' => 0,
-        'course' => null    // This isn't in the form.
+            'recompletiontype' => '',
+            'recompletionduration' => 0,
+            'recompletionschedule' => '',
+            'assignevent' => null,
+            'archivecompletiondata' => 0,
+            'recompletionnotify' => '',
+            'recompletionunenrolenable' => 0,
+            'recompletionemailbody' => '',
+            'recompletionemailbody_format' => FORMAT_HTML,
+            'recompletionemailsubject' => '',
+            'deletegradedata' => 0,
+            'nextresettime' => 0,
+            'course' => null,    // This isn't in the form.
     ];
 
     $config = $defaultconfig;
-    $dbconfig = $DB->get_records_menu('local_recompletion_config', array('course' => $course->id), '', 'name, value');
+    $dbconfig = $DB->get_records_menu('local_recompletion_config', ['course' => $course->id], '', 'name, value');
     // If we get no values back, then we use the default above, otherwise update the config with the DB values a precedent.
     // We could also combine the settings values so that the code calling it doesn't need to do this.
     if (!empty($dbconfig)) {
@@ -180,7 +184,7 @@ function local_recompletion_get_config($course) {
     }
     $config['course'] = $course->id;
 
-    $config = (object)$config;
+    $config = (object) $config;
     return $config;
 }
 

--- a/participants.php
+++ b/participants.php
@@ -23,42 +23,45 @@
  */
 
 require_once('../../config.php');
-require_once($CFG->dirroot.'/user/lib.php');
-require_once($CFG->dirroot.'/course/lib.php');
-require_once($CFG->dirroot.'/notes/lib.php');
-require_once($CFG->libdir.'/tablelib.php');
-require_once($CFG->libdir.'/filelib.php');
-require_once($CFG->dirroot.'/enrol/locallib.php');
+require_once($CFG->dirroot . '/user/lib.php');
+require_once($CFG->dirroot . '/course/lib.php');
+require_once($CFG->dirroot . '/notes/lib.php');
+require_once($CFG->libdir . '/tablelib.php');
+require_once($CFG->libdir . '/filelib.php');
+require_once($CFG->dirroot . '/enrol/locallib.php');
 
+use core_group\output\group_details;
 use core_table\local\filter\filter;
 use core_table\local\filter\integer_filter;
 use core_table\local\filter\string_filter;
+use local_recompletion\table\participants;
+use local_recompletion\table\participants_filterset;
 
 define('DEFAULT_PAGE_SIZE', 20);
 
-$page         = optional_param('page', 0, PARAM_INT); // Which page to show.
-$perpage      = optional_param('perpage', DEFAULT_PAGE_SIZE, PARAM_INT); // How many per page.
-$contextid    = optional_param('contextid', 0, PARAM_INT); // One of this or.
-$courseid     = optional_param('id', 0, PARAM_INT); // This are required.
-$newcourse    = optional_param('newcourse', false, PARAM_BOOL);
-$roleid       = optional_param('roleid', 0, PARAM_INT);
-$urlgroupid   = optional_param('group', 0, PARAM_INT);
+$page = optional_param('page', 0, PARAM_INT); // Which page to show.
+$perpage = optional_param('perpage', DEFAULT_PAGE_SIZE, PARAM_INT); // How many per page.
+$contextid = optional_param('contextid', 0, PARAM_INT); // One of this or.
+$courseid = optional_param('id', 0, PARAM_INT); // This are required.
+$newcourse = optional_param('newcourse', false, PARAM_BOOL);
+$roleid = optional_param('roleid', 0, PARAM_INT);
+$urlgroupid = optional_param('group', 0, PARAM_INT);
 
-$PAGE->set_url('/local/recompletion/participants.php', array(
-    'page' => $page,
-    'perpage' => $perpage,
-    'contextid' => $contextid,
-    'id' => $courseid,
-    'newcourse' => $newcourse));
+$PAGE->set_url('/local/recompletion/participants.php', [
+        'page' => $page,
+        'perpage' => $perpage,
+        'contextid' => $contextid,
+        'id' => $courseid,
+        'newcourse' => $newcourse]);
 
 if ($contextid) {
     $context = context::instance_by_id($contextid, MUST_EXIST);
     if ($context->contextlevel != CONTEXT_COURSE) {
         throw new moodle_exception('invalidcontext');
     }
-    $course = $DB->get_record('course', array('id' => $context->instanceid), '*', MUST_EXIST);
+    $course = $DB->get_record('course', ['id' => $context->instanceid], '*', MUST_EXIST);
 } else {
-    $course = $DB->get_record('course', array('id' => $courseid), '*', MUST_EXIST);
+    $course = $DB->get_record('course', ['id' => $courseid], '*', MUST_EXIST);
     $context = context_course::instance($course->id, MUST_EXIST);
 }
 // Not needed anymore.
@@ -85,7 +88,7 @@ user_list_view($course, $context);
 
 $bulkoperations = has_capability('local/recompletion:bulkoperations', $context);
 
-$PAGE->set_title("$course->shortname: ".get_string('participants'));
+$PAGE->set_title("$course->shortname: " . get_string('participants'));
 $PAGE->set_heading($course->fullname);
 $PAGE->set_pagetype('course-view-' . $course->format);
 $PAGE->set_docs_path('enrol/users');
@@ -95,10 +98,10 @@ $PAGE->set_other_editing_capability('moodle/course:manageactivities');
 echo $OUTPUT->header();
 echo $OUTPUT->heading(get_string('participants'));
 
-$filterset = new \local_recompletion\table\participants_filterset();
-$filterset->add_filter(new integer_filter('courseid', filter::JOINTYPE_DEFAULT, [(int)$course->id]));
+$filterset = new participants_filterset();
+$filterset->add_filter(new integer_filter('courseid', filter::JOINTYPE_DEFAULT, [(int) $course->id]));
 
-$participanttable = new \local_recompletion\table\participants("user-recompletion-participants-{$course->id}");
+$participanttable = new participants("user-recompletion-participants-{$course->id}");
 
 $canaccessallgroups = has_capability('moodle/site:accessallgroups', $context);
 $filtergroupids = $urlgroupid ? [$urlgroupid] : [];
@@ -107,8 +110,8 @@ $filtergroupids = $urlgroupid ? [$urlgroupid] : [];
 if ($course->groupmode != NOGROUPS && !$canaccessallgroups) {
     if ($filtergroupids) {
         $filtergroupids = array_intersect(
-            $filtergroupids,
-            array_keys(groups_get_all_groups($course->id, $USER->id))
+                $filtergroupids,
+                array_keys(groups_get_all_groups($course->id, $USER->id))
         );
     } else {
         $filtergroupids = array_keys(groups_get_all_groups($course->id, $USER->id));
@@ -134,7 +137,7 @@ if (!empty($filtergroupids)) {
 // Display single group information if requested in the URL.
 if ($urlgroupid > 0 && ($course->groupmode != SEPARATEGROUPS || $canaccessallgroups)) {
     $grouprenderer = $PAGE->get_renderer('core_group');
-    $groupdetailpage = new \core_group\output\group_details($urlgroupid);
+    $groupdetailpage = new group_details($urlgroupid);
     echo $grouprenderer->group_details($groupdetailpage);
 }
 
@@ -158,8 +161,8 @@ foreach ($enrolbuttons as $enrolbutton) {
 }
 
 echo html_writer::div($enrolbuttonsout, 'd-flex justify-content-end', [
-    'data-region' => 'wrapper',
-    'data-table-uniqueid' => $participanttable->uniqueid,
+        'data-region' => 'wrapper',
+        'data-table-uniqueid' => $participanttable->uniqueid,
 ]);
 
 // Render the user filters.
@@ -176,30 +179,31 @@ $participanttablehtml = ob_get_contents();
 ob_end_clean();
 
 echo html_writer::start_tag('form', [
-    'action' => 'editcompletion.php',
-    'method' => 'post',
-    'id' => 'participantsform',
-    'data-course-id' => $course->id,
-    'data-table-unique-id' => $participanttable->uniqueid,
+        'action' => 'editcompletion.php',
+        'method' => 'post',
+        'id' => 'participantsform',
+        'data-course-id' => $course->id,
+        'data-table-unique-id' => $participanttable->uniqueid,
 ]);
 echo '<div>';
-echo '<input type="hidden" name="sesskey" value="'.sesskey().'" />';
-echo '<input type="hidden" name="returnto" value="'.s($PAGE->url->out(false)).'" />';
+echo '<input type="hidden" name="sesskey" value="' . sesskey() . '" />';
+echo '<input type="hidden" name="returnto" value="' . s($PAGE->url->out(false)) . '" />';
 
 echo html_writer::tag(
-    'p',
-    get_string('countparticipantsfound', 'core_user', $participanttable->totalrows),
-    [
-        'data-region' => 'participant-count',
-    ]
+        'p',
+        get_string('countparticipantsfound', 'core_user', $participanttable->totalrows),
+        [
+                'data-region' => 'participant-count',
+        ]
 );
 
 echo $participanttablehtml;
 
 if ($bulkoperations) {
     echo '<br /><div class="buttons"><div class="form-inline">';
-    echo '<input type="submit" name="submit" value="'.get_string('bulkchangedate', 'local_recompletion').'"/>';
-    echo '<input type="submit" name="reset_completion" value="'.get_string('bulkresetallcompletion', 'local_recompletion').'"/>';
+    echo '<input type="submit" name="submit" value="' . get_string('bulkchangedate', 'local_recompletion') . '"/>';
+    echo '<input type="submit" name="reset_completion" value="' . get_string('bulkresetallcompletion', 'local_recompletion') .
+            '"/>';
     echo '<input type="hidden" name="id" value="' . $course->id . '" />';
     echo '</div></div>';
 }
@@ -215,8 +219,8 @@ foreach ($enrolbuttons as $enrolbutton) {
     $enrolbuttonsout .= $enrolrenderer->render($enrolbutton);
 }
 echo html_writer::div($enrolbuttonsout, 'd-flex justify-content-end', [
-    'data-region' => 'wrapper',
-    'data-table-uniqueid' => $participanttable->uniqueid,
+        'data-region' => 'wrapper',
+        'data-table-uniqueid' => $participanttable->uniqueid,
 ]);
 
 echo $OUTPUT->footer();

--- a/recompletion.php
+++ b/recompletion.php
@@ -22,11 +22,11 @@
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(__DIR__.'/../../config.php');
-require_once($CFG->dirroot.'/local/recompletion/locallib.php');
-require_once($CFG->dirroot.'/course/lib.php');
-require_once($CFG->libdir.'/completionlib.php');
-require_once($CFG->libdir.'/formslib.php');
+require_once(__DIR__ . '/../../config.php');
+require_once($CFG->dirroot . '/local/recompletion/locallib.php');
+require_once($CFG->dirroot . '/course/lib.php');
+require_once($CFG->libdir . '/completionlib.php');
+require_once($CFG->libdir . '/formslib.php');
 
 $id = required_param('id', PARAM_INT);
 
@@ -70,19 +70,19 @@ if (!empty(get_config('local_recompletion', 'forcearchivecompletiondata'))) {
 }
 
 $setnames = [
-    'recompletiontype',
-    'recompletionduration',
-    'recompletionschedule',
-    'deletegradedata',
-    'archivecompletiondata',
-    'recompletionnotify',
-    'recompletionunenrolenable',
-    'recompletionemailsubject',
-    'recompletionemailbody',
-    'recompletionemailbody_format',
-    'assignevent',
-    'nextresettime',
-    'resetquizoverride',
+        'recompletiontype',
+        'recompletionduration',
+        'recompletionschedule',
+        'deletegradedata',
+        'archivecompletiondata',
+        'recompletionnotify',
+        'recompletionunenrolenable',
+        'recompletionemailsubject',
+        'recompletionemailbody',
+        'recompletionemailbody_format',
+        'assignevent',
+        'nextresettime',
+        'resetquizoverride',
 ];
 
 $plugins = local_recompletion_get_supported_plugins();
@@ -92,7 +92,7 @@ foreach ($plugins as $plugin) {
         $plugin = str_replace('mod_', '', $plugin);
     }
     $setnames[] = $plugin;
-    $setnames[] = 'archive'.$plugin;
+    $setnames[] = 'archive' . $plugin;
 }
 
 $restrictions = local_recompletion_get_supported_restrictions();
@@ -105,10 +105,10 @@ $customdata = ['course' => $course];
 if (!empty($config)) {
     $customdata['instance'] = local_recompletion_get_data($config);
 }
-$form = new local_recompletion_recompletion_form('recompletion.php?id='.$id, $customdata);
+$form = new local_recompletion_recompletion_form('recompletion.php?id=' . $id, $customdata);
 
 if ($form->is_cancelled()) {
-    redirect($CFG->wwwroot.'/course/view.php?id='.$course->id);
+    redirect($CFG->wwwroot . '/course/view.php?id=' . $course->id);
 } else if ($data = $form->get_data()) {
     $data = local_recompletion_set_form_data($data);
     foreach ($setnames as $name) {
@@ -120,7 +120,7 @@ if ($form->is_cancelled()) {
 
         if ($name === 'nextresettime') {
             $value = $data->recompletionschedulestart > 0 ?
-                $data->recompletionschedulestart : local_recompletion_calculate_schedule_time($data->recompletionschedule);
+                    $data->recompletionschedulestart : local_recompletion_calculate_schedule_time($data->recompletionschedule);
         }
 
         if (isset($data->$name)) {

--- a/resetcompletion.php
+++ b/resetcompletion.php
@@ -22,8 +22,10 @@
  * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-require_once(__DIR__.'/../../config.php');
-require_once($CFG->dirroot.'/local/recompletion/locallib.php');
+use core\output\notification;
+
+require_once(__DIR__ . '/../../config.php');
+require_once($CFG->dirroot . '/local/recompletion/locallib.php');
 
 $id = required_param('id', PARAM_INT); // Course id.
 $confirm = optional_param('confirm', '', PARAM_INT);
@@ -33,7 +35,7 @@ if ($id == SITEID) {
     // Don't allow editing of 'site course' using this form.
     throw new moodle_exception('cannoteditsiteform');
 }
-$course = $DB->get_record('course', array('id' => $id), '*', MUST_EXIST);
+$course = $DB->get_record('course', ['id' => $id], '*', MUST_EXIST);
 require_login($course);
 
 if (empty($userid)) {
@@ -42,9 +44,9 @@ if (empty($userid)) {
 
 $context = context_course::instance($course->id);
 if ($USER->id <> $userid) {
-    $cancelurl = new moodle_url('/local/recompletion/participants.php', array('id' => $course->id));
+    $cancelurl = new moodle_url('/local/recompletion/participants.php', ['id' => $course->id]);
     require_capability('local/recompletion:manage', $context);
-    $user = $DB->get_record('user', array('id' => $userid));
+    $user = $DB->get_record('user', ['id' => $userid]);
 } else {
     $cancelurl = course_get_url($course);
     require_capability('local/recompletion:resetmycompletion', $context);
@@ -55,12 +57,12 @@ if (!empty($confirm) && confirm_sesskey()) {
     $reset = new local_recompletion\task\check_recompletion();
     $errors = $reset->reset_user($userid, $course);
     if ($USER->id <> $userid) {
-        $returnurl = new moodle_url('/local/recompletion/participants.php', array('id' => $course->id));
+        $returnurl = new moodle_url('/local/recompletion/participants.php', ['id' => $course->id]);
     } else {
         $returnurl = course_get_url($course);
     }
     if (!empty($errors)) {
-        redirect($returnurl, implode(', ', $errors), '',  \core\output\notification::NOTIFY_WARNING);
+        redirect($returnurl, implode(', ', $errors), '', notification::NOTIFY_WARNING);
     } else {
         redirect($returnurl, get_string('completionresetuser', 'local_recompletion', fullname($user)));
     }
@@ -69,7 +71,7 @@ if (!empty($confirm) && confirm_sesskey()) {
 
 // Set up the page.
 $PAGE->set_course($course);
-$PAGE->set_url('/local/recompletion/resetcompletion.php', array('id' => $course->id));
+$PAGE->set_url('/local/recompletion/resetcompletion.php', ['id' => $course->id]);
 $PAGE->set_title($course->shortname);
 $PAGE->set_heading($course->fullname);
 

--- a/settings.php
+++ b/settings.php
@@ -34,86 +34,86 @@ if ($hassiteconfig) {
 
     // Type of recompletion - range(duration) or schedule(absolute times, based on cron schedule).
     $settings->add(new admin_setting_configselect('local_recompletion/recompletiontype',
-        new lang_string('recompletiontype', 'local_recompletion'),
-        new lang_string('recompletiontype_help', 'local_recompletion'),
-        local_recompletion_recompletion_form::RECOMPLETION_TYPE_DISABLED,
-        [
-            local_recompletion_recompletion_form::RECOMPLETION_TYPE_DISABLED => get_string(
-                'recompletiontype:disabled',
-                'local_recompletion'
-            ),
-            local_recompletion_recompletion_form::RECOMPLETION_TYPE_PERIOD => get_string(
-                'recompletiontype:period',
-                'local_recompletion',
-            ),
-            local_recompletion_recompletion_form::RECOMPLETION_TYPE_ONDEMAND => get_string(
-                'recompletiontype:ondemand',
-                'local_recompletion',
-            ),
-            local_recompletion_recompletion_form::RECOMPLETION_TYPE_SCHEDULE => get_string(
-                'recompletiontype:schedule',
-                'local_recompletion',
-            ),
-        ]));
+            new lang_string('recompletiontype', 'local_recompletion'),
+            new lang_string('recompletiontype_help', 'local_recompletion'),
+            local_recompletion_recompletion_form::RECOMPLETION_TYPE_DISABLED,
+            [
+                    local_recompletion_recompletion_form::RECOMPLETION_TYPE_DISABLED => get_string(
+                            'recompletiontype:disabled',
+                            'local_recompletion'
+                    ),
+                    local_recompletion_recompletion_form::RECOMPLETION_TYPE_PERIOD => get_string(
+                            'recompletiontype:period',
+                            'local_recompletion',
+                    ),
+                    local_recompletion_recompletion_form::RECOMPLETION_TYPE_ONDEMAND => get_string(
+                            'recompletiontype:ondemand',
+                            'local_recompletion',
+                    ),
+                    local_recompletion_recompletion_form::RECOMPLETION_TYPE_SCHEDULE => get_string(
+                            'recompletiontype:schedule',
+                            'local_recompletion',
+                    ),
+            ]));
 
     $settings->add(new admin_setting_configstrtotime('local_recompletion/recompletionschedule',
-        new lang_string('recompletionschedule', 'local_recompletion'),
-        new lang_string('recompletionschedule_help', 'local_recompletion'), 'Jan 1', PARAM_TEXT));
+            new lang_string('recompletionschedule', 'local_recompletion'),
+            new lang_string('recompletionschedule_help', 'local_recompletion'), 'Jan 1', PARAM_TEXT));
 
     $settings->add(new admin_setting_configduration('local_recompletion/recompletionduration',
-        new lang_string('recompletionrange', 'local_recompletion'),
-        new lang_string('recompletionrange_help', 'local_recompletion'), YEARSECS, PARAM_INT));
+            new lang_string('recompletionrange', 'local_recompletion'),
+            new lang_string('recompletionrange_help', 'local_recompletion'), YEARSECS, PARAM_INT));
 
     $settings->add(new admin_setting_configselect('local_recompletion/recompletionnotify',
-        new lang_string('recompletionnotify', 'local_recompletion'),
-        new lang_string('recompletionnotify_help', 'local_recompletion'),
-        local_recompletion_recompletion_form::RECOMPLETION_NOTIFY_DISABLED,
-        [
-            local_recompletion_recompletion_form::RECOMPLETION_NOTIFY_DISABLED => get_string(
-                'recompletiontype:disabled',
-                'local_recompletion',
-            ),
-            local_recompletion_recompletion_form::RECOMPLETION_NOTIFY_COMPLETED_USERS => get_string(
-                'recompletionnotify:completed',
-                'local_recompletion',
-            ),
-            local_recompletion_recompletion_form::RECOMPLETION_NOTIFY_ACTIVE_ENROLLED_USERS => get_string(
-                'recompletionnotify:activeenrolled',
-                'local_recompletion',
-            ),
-            local_recompletion_recompletion_form::RECOMPLETION_NOTIFY_ENROLLED_USERS => get_string(
-                'recompletionnotify:enrolled',
-                'local_recompletion',
-            ),
-        ]));
+            new lang_string('recompletionnotify', 'local_recompletion'),
+            new lang_string('recompletionnotify_help', 'local_recompletion'),
+            local_recompletion_recompletion_form::RECOMPLETION_NOTIFY_DISABLED,
+            [
+                    local_recompletion_recompletion_form::RECOMPLETION_NOTIFY_DISABLED => get_string(
+                            'recompletiontype:disabled',
+                            'local_recompletion',
+                    ),
+                    local_recompletion_recompletion_form::RECOMPLETION_NOTIFY_COMPLETED_USERS => get_string(
+                            'recompletionnotify:completed',
+                            'local_recompletion',
+                    ),
+                    local_recompletion_recompletion_form::RECOMPLETION_NOTIFY_ACTIVE_ENROLLED_USERS => get_string(
+                            'recompletionnotify:activeenrolled',
+                            'local_recompletion',
+                    ),
+                    local_recompletion_recompletion_form::RECOMPLETION_NOTIFY_ENROLLED_USERS => get_string(
+                            'recompletionnotify:enrolled',
+                            'local_recompletion',
+                    ),
+            ]));
 
     $settings->add(new admin_setting_configtext('local_recompletion/recompletionemailsubject',
-        new lang_string('recompletionemailsubject', 'local_recompletion'),
-        new lang_string('recompletionemailsubject_help', 'local_recompletion'), '', PARAM_TEXT));
+            new lang_string('recompletionemailsubject', 'local_recompletion'),
+            new lang_string('recompletionemailsubject_help', 'local_recompletion'), '', PARAM_TEXT));
 
     $settings->add(new admin_setting_confightmleditor('local_recompletion/recompletionemailbody',
-        new lang_string('recompletionemailbody', 'local_recompletion'),
-        new lang_string('recompletionemailbody_help', 'local_recompletion'), ''));
+            new lang_string('recompletionemailbody', 'local_recompletion'),
+            new lang_string('recompletionemailbody_help', 'local_recompletion'), ''));
 
     $settings->add(new admin_setting_configcheckbox('local_recompletion/recompletionunenrolenable',
-        new lang_string('recompletionunenrolenable', 'local_recompletion'),
-        new lang_string('recompletionunenrolenable_help', 'local_recompletion'), 0));
+            new lang_string('recompletionunenrolenable', 'local_recompletion'),
+            new lang_string('recompletionunenrolenable_help', 'local_recompletion'), 0));
 
     $settings->add(new admin_setting_configcheckbox('local_recompletion/deletegradedata',
-        new lang_string('deletegradedata', 'local_recompletion'),
-        new lang_string('deletegradedata_help', 'local_recompletion'), 1));
+            new lang_string('deletegradedata', 'local_recompletion'),
+            new lang_string('deletegradedata_help', 'local_recompletion'), 1));
 
     $settings->add(new admin_setting_configcheckbox('local_recompletion/archivecompletiondata',
-        new lang_string('archivecompletiondata', 'local_recompletion'),
-        new lang_string('archivecompletiondata_help', 'local_recompletion'), 1));
+            new lang_string('archivecompletiondata', 'local_recompletion'),
+            new lang_string('archivecompletiondata_help', 'local_recompletion'), 1));
 
     $settings->add(new admin_setting_configcheckbox('local_recompletion/forcearchivecompletiondata',
-        new lang_string('forcearchivecompletiondata', 'local_recompletion'),
-        new lang_string('forcearchivecompletiondata_help', 'local_recompletion'), 0));
+            new lang_string('forcearchivecompletiondata', 'local_recompletion'),
+            new lang_string('forcearchivecompletiondata_help', 'local_recompletion'), 0));
 
     $settings->add(new admin_setting_heading('local_recompletion/pluginsettings',
-        get_string('pluginssettings', 'local_recompletion'),
-        ''
+            get_string('pluginssettings', 'local_recompletion'),
+            ''
     ));
 
     $plugins = local_recompletion_get_supported_plugins();
@@ -123,8 +123,8 @@ if ($hassiteconfig) {
     }
 
     $settings->add(new admin_setting_heading('local_recompletion/restrictionsettings',
-        get_string('restrictionsettings', 'local_recompletion'),
-        ''
+            get_string('restrictionsettings', 'local_recompletion'),
+            ''
     ));
 
     $restrictions = local_recompletion_get_supported_restrictions();

--- a/tests/local/restrictions/enrol_test.php
+++ b/tests/local/restrictions/enrol_test.php
@@ -16,6 +16,7 @@
 
 namespace local_recompletion\local\restrictions;
 
+use advanced_testcase;
 use stdClass;
 
 /**
@@ -26,7 +27,7 @@ use stdClass;
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  * @covers     \local_recompletion\local\restrictions\enrol
  */
-class enrol_test extends \advanced_testcase {
+class enrol_test extends advanced_testcase {
 
     /**
      * Test that method doesn't add restrictenrol attribute if not present in data.
@@ -45,12 +46,12 @@ class enrol_test extends \advanced_testcase {
      */
     public function set_form_data_data_provider(): array {
         return [
-            ['', ''],
-            [1, 1],
-            ['data', 'data'],
-            [(object)['data'], (object)['data']],
-            [['data'], 'data'],
-            [['data 1', 'data 2'], 'data 1,data 2'],
+                ['', ''],
+                [1, 1],
+                ['data', 'data'],
+                [(object) ['data'], (object) ['data']],
+                [['data'], 'data'],
+                [['data 1', 'data 2'], 'data 1,data 2'],
         ];
     }
 
@@ -80,25 +81,25 @@ class enrol_test extends \advanced_testcase {
         $usermanual = $this->getDataGenerator()->create_and_enrol($course);
         $userself = $this->getDataGenerator()->create_and_enrol($course, 'student', null, 'self');
 
-        $this->assertTrue(enrol::should_reset($usermanual->id, $course, (object)[]));
-        $this->assertTrue(enrol::should_reset($userself->id, $course, (object)[]));
+        $this->assertTrue(enrol::should_reset($usermanual->id, $course, (object) []));
+        $this->assertTrue(enrol::should_reset($userself->id, $course, (object) []));
 
-        $this->assertTrue(enrol::should_reset($usermanual->id, $course, (object)['restrictenrol' => ['paypal']]));
-        $this->assertTrue(enrol::should_reset($userself->id, $course, (object)['restrictenrol' => ['paypal']]));
+        $this->assertTrue(enrol::should_reset($usermanual->id, $course, (object) ['restrictenrol' => ['paypal']]));
+        $this->assertTrue(enrol::should_reset($userself->id, $course, (object) ['restrictenrol' => ['paypal']]));
 
-        $this->assertFalse(enrol::should_reset($usermanual->id, $course, (object)['restrictenrol' => 'paypal']));
-        $this->assertFalse(enrol::should_reset($userself->id, $course, (object)['restrictenrol' => 'paypal']));
+        $this->assertFalse(enrol::should_reset($usermanual->id, $course, (object) ['restrictenrol' => 'paypal']));
+        $this->assertFalse(enrol::should_reset($userself->id, $course, (object) ['restrictenrol' => 'paypal']));
 
-        $this->assertFalse(enrol::should_reset($usermanual->id, $course, (object)['restrictenrol' => 'self']));
-        $this->assertTrue(enrol::should_reset($userself->id, $course, (object)['restrictenrol' => 'self']));
+        $this->assertFalse(enrol::should_reset($usermanual->id, $course, (object) ['restrictenrol' => 'self']));
+        $this->assertTrue(enrol::should_reset($userself->id, $course, (object) ['restrictenrol' => 'self']));
 
-        $this->assertTrue(enrol::should_reset($usermanual->id, $course, (object)['restrictenrol' => 'manual']));
-        $this->assertFalse(enrol::should_reset($userself->id, $course, (object)['restrictenrol' => 'manual']));
+        $this->assertTrue(enrol::should_reset($usermanual->id, $course, (object) ['restrictenrol' => 'manual']));
+        $this->assertFalse(enrol::should_reset($userself->id, $course, (object) ['restrictenrol' => 'manual']));
 
-        $this->assertFalse(enrol::should_reset($usermanual->id, $course, (object)['restrictenrol' => 'paypal,self']));
-        $this->assertTrue(enrol::should_reset($userself->id, $course, (object)['restrictenrol' => 'paypal,self']));
+        $this->assertFalse(enrol::should_reset($usermanual->id, $course, (object) ['restrictenrol' => 'paypal,self']));
+        $this->assertTrue(enrol::should_reset($userself->id, $course, (object) ['restrictenrol' => 'paypal,self']));
 
-        $this->assertTrue(enrol::should_reset($usermanual->id, $course, (object)['restrictenrol' => 'paypal,self,manual']));
-        $this->assertTrue(enrol::should_reset($userself->id, $course, (object)['restrictenrol' => 'paypal,self,manual']));
+        $this->assertTrue(enrol::should_reset($usermanual->id, $course, (object) ['restrictenrol' => 'paypal,self,manual']));
+        $this->assertTrue(enrol::should_reset($userself->id, $course, (object) ['restrictenrol' => 'paypal,self,manual']));
     }
 }

--- a/tests/observer_test.php
+++ b/tests/observer_test.php
@@ -16,6 +16,9 @@
 
 namespace local_recompletion;
 
+use advanced_testcase;
+use completion_completion;
+
 /**
  * Observer_test.
  *
@@ -25,7 +28,7 @@ namespace local_recompletion;
  *
  * @covers \local_recompletion\observer
  */
-class observer_test extends \advanced_testcase {
+class observer_test extends advanced_testcase {
 
     /**
      * Set up recompletion for a given course.
@@ -39,20 +42,20 @@ class observer_test extends \advanced_testcase {
         $DB->delete_records('local_recompletion_config', ['course' => $courseid]);
 
         $defaultconfig = [
-            'recompletiontype' => 'ondemand',
-            'recompletionunenrolenable' => 1,
-            'archivecompletiondata' => 0,
-            'deletegradedata' => 1,
-            'recompletionnotify' => '',
+                'recompletiontype' => 'ondemand',
+                'recompletionunenrolenable' => 1,
+                'archivecompletiondata' => 0,
+                'deletegradedata' => 1,
+                'recompletionnotify' => '',
         ];
 
         $config = array_merge($defaultconfig, $config);
 
         foreach ($config as $name => $value) {
             $DB->insert_record('local_recompletion_config', (object) [
-                'course' => $courseid,
-                'name' => $name,
-                'value' => $value,
+                    'course' => $courseid,
+                    'name' => $name,
+                    'value' => $value,
             ]);
         }
     }
@@ -83,8 +86,8 @@ class observer_test extends \advanced_testcase {
         // Make sure we trigger reset on un-enrolment.
         $this->set_up_recompletion($course->id, ['recompletionunenrolenable' => 1]);
 
-        $compluser1 = new \completion_completion(['userid' => $user1->id, 'course' => $course->id]);
-        $compluser2 = new \completion_completion(['userid' => $user2->id, 'course' => $course->id]);
+        $compluser1 = new completion_completion(['userid' => $user1->id, 'course' => $course->id]);
+        $compluser2 = new completion_completion(['userid' => $user2->id, 'course' => $course->id]);
 
         // Initially both users are not completed.
         $this->assertFalse($compluser1->is_complete());
@@ -94,8 +97,8 @@ class observer_test extends \advanced_testcase {
         $compluser1->mark_complete(0);
         $compluser2->mark_complete(0);
 
-        $compluser1 = new \completion_completion(['userid' => $user1->id, 'course' => $course->id]);
-        $compluser2 = new \completion_completion(['userid' => $user2->id, 'course' => $course->id]);
+        $compluser1 = new completion_completion(['userid' => $user1->id, 'course' => $course->id]);
+        $compluser2 = new completion_completion(['userid' => $user2->id, 'course' => $course->id]);
 
         $this->assertTrue($compluser1->is_complete());
         $this->assertTrue($compluser2->is_complete());
@@ -104,15 +107,15 @@ class observer_test extends \advanced_testcase {
         $enrol->unenrol_user($enrolinstance, $user1->id);
 
         // Confirm that user 1 is not completed anymore as he's unenrolled form a course. User 2 should still be completed.
-        $compluser1 = new \completion_completion(['userid' => $user1->id, 'course' => $course->id]);
-        $compluser2 = new \completion_completion(['userid' => $user2->id, 'course' => $course->id]);
+        $compluser1 = new completion_completion(['userid' => $user1->id, 'course' => $course->id]);
+        $compluser2 = new completion_completion(['userid' => $user2->id, 'course' => $course->id]);
         $this->assertFalse($compluser1->is_complete());
         $this->assertTrue($compluser2->is_complete());
 
         // Enrol back user 1 and confirm he's still not completed.
         $enrol->enrol_user($enrolinstance, $user1->id, $studentrole->id);
-        $compluser1 = new \completion_completion(['userid' => $user1->id, 'course' => $course->id]);
-        $compluser2 = new \completion_completion(['userid' => $user2->id, 'course' => $course->id]);
+        $compluser1 = new completion_completion(['userid' => $user1->id, 'course' => $course->id]);
+        $compluser2 = new completion_completion(['userid' => $user2->id, 'course' => $course->id]);
         $this->assertFalse($compluser1->is_complete());
         $this->assertTrue($compluser2->is_complete());
 
@@ -121,8 +124,8 @@ class observer_test extends \advanced_testcase {
 
         // Unenrol completed user 2.
         $enrol->unenrol_user($enrolinstance, $user2->id);
-        $compluser1 = new \completion_completion(['userid' => $user1->id, 'course' => $course->id]);
-        $compluser2 = new \completion_completion(['userid' => $user2->id, 'course' => $course->id]);
+        $compluser1 = new completion_completion(['userid' => $user1->id, 'course' => $course->id]);
+        $compluser2 = new completion_completion(['userid' => $user2->id, 'course' => $course->id]);
 
         // Confirm completion status is still completed for a user 2. User 1 should be without changes.
         $this->assertFalse($compluser1->is_complete());
@@ -130,8 +133,8 @@ class observer_test extends \advanced_testcase {
 
         // Enrol back user 2.
         $enrol->enrol_user($enrolinstance, $user2->id, $studentrole->id);
-        $compluser1 = new \completion_completion(['userid' => $user1->id, 'course' => $course->id]);
-        $compluser2 = new \completion_completion(['userid' => $user2->id, 'course' => $course->id]);
+        $compluser1 = new completion_completion(['userid' => $user1->id, 'course' => $course->id]);
+        $compluser2 = new completion_completion(['userid' => $user2->id, 'course' => $course->id]);
 
         // Completion status should be still completed for a user 2. User 1 should be without changes.
         $this->assertFalse($compluser1->is_complete());

--- a/tests/plugins/mod_h5pactivity_test.php
+++ b/tests/plugins/mod_h5pactivity_test.php
@@ -16,6 +16,8 @@
 
 namespace local_recompletion\plugins;
 
+use advanced_testcase;
+
 /**
  * Tests for mod_h5pactivity.
  *
@@ -25,7 +27,7 @@ namespace local_recompletion\plugins;
  *
  * @covers \local_recompletion\plugins\mod_h5pactivity
  */
-class mod_h5pactivity_test extends \advanced_testcase {
+class mod_h5pactivity_test extends advanced_testcase {
 
     /**
      * Test mod_h5pactivity recompletion.
@@ -51,7 +53,7 @@ class mod_h5pactivity_test extends \advanced_testcase {
         $generator->create_attempt(['h5pactivityid' => $h5p->id, 'userid' => $user1->id]);
 
         // Reset user 2 without any attempts to make sure that it doesn't explode.
-        mod_h5pactivity::reset($user2->id, $course, (object)['h5pactivity' => 1, 'archiveh5pactivity' => 1]);
+        mod_h5pactivity::reset($user2->id, $course, (object) ['h5pactivity' => 1, 'archiveh5pactivity' => 1]);
 
         // Check that data is created in original tables.
         $this->assertTrue($DB->record_exists('h5pactivity_attempts', ['userid' => $user1->id, 'h5pactivityid' => $h5p->id]));
@@ -60,7 +62,7 @@ class mod_h5pactivity_test extends \advanced_testcase {
         $this->assertFalse($DB->record_exists('local_recompletion_h5pr', []));
 
         // Reset data with "do nothing".
-        mod_h5pactivity::reset($user1->id, $course, (object)['h5pactivity' => 0, 'archiveh5pactivity' => 0]);
+        mod_h5pactivity::reset($user1->id, $course, (object) ['h5pactivity' => 0, 'archiveh5pactivity' => 0]);
 
         // Check that nothing happened.
         $this->assertTrue($DB->record_exists('h5pactivity_attempts', ['userid' => $user1->id, 'h5pactivityid' => $h5p->id]));
@@ -69,7 +71,7 @@ class mod_h5pactivity_test extends \advanced_testcase {
         $this->assertFalse($DB->record_exists('local_recompletion_h5pr', []));
 
         // Reset data with "do nothing", but archiving enabled.
-        mod_h5pactivity::reset($user1->id, $course, (object)['h5pactivity' => 0, 'archiveh5pactivity' => 1]);
+        mod_h5pactivity::reset($user1->id, $course, (object) ['h5pactivity' => 0, 'archiveh5pactivity' => 1]);
 
         // Check that nothing happened.
         $this->assertTrue($DB->record_exists('h5pactivity_attempts', ['userid' => $user1->id, 'h5pactivityid' => $h5p->id]));
@@ -78,7 +80,7 @@ class mod_h5pactivity_test extends \advanced_testcase {
         $this->assertFalse($DB->record_exists('local_recompletion_h5pr', []));
 
         // Reset data for user 2.
-        mod_h5pactivity::reset($user2->id, $course, (object)['h5pactivity' => 1, 'archiveh5pactivity' => 0]);
+        mod_h5pactivity::reset($user2->id, $course, (object) ['h5pactivity' => 1, 'archiveh5pactivity' => 0]);
 
         // Check that nothing happened for user 1.
         $this->assertTrue($DB->record_exists('h5pactivity_attempts', ['userid' => $user1->id, 'h5pactivityid' => $h5p->id]));
@@ -87,7 +89,7 @@ class mod_h5pactivity_test extends \advanced_testcase {
         $this->assertFalse($DB->record_exists('local_recompletion_h5pr', []));
 
         // Reset data without archiving.
-        mod_h5pactivity::reset($user1->id, $course, (object)['h5pactivity' => 1, 'archiveh5pactivity' => 0]);
+        mod_h5pactivity::reset($user1->id, $course, (object) ['h5pactivity' => 1, 'archiveh5pactivity' => 0]);
 
         // Check data is gone from original tables.
         $this->assertFalse($DB->record_exists('h5pactivity_attempts', ['userid' => $user1->id, 'h5pactivityid' => $h5p->id]));
@@ -108,7 +110,7 @@ class mod_h5pactivity_test extends \advanced_testcase {
         $originalresult = $DB->get_record('h5pactivity_attempts_results', ['attemptid' => $originalattempt->id]);
 
         // Reset with archiving.
-        mod_h5pactivity::reset($user1->id, $course, (object)['h5pactivity' => 1, 'archiveh5pactivity' => 1]);
+        mod_h5pactivity::reset($user1->id, $course, (object) ['h5pactivity' => 1, 'archiveh5pactivity' => 1]);
 
         // Check that data is created in archived tables.
         $this->assertFalse($DB->record_exists('h5pactivity_attempts', ['userid' => $user1->id, 'h5pactivityid' => $h5p->id]));
@@ -159,14 +161,14 @@ class mod_h5pactivity_test extends \advanced_testcase {
         $generator->create_attempt(['h5pactivityid' => $h5p->id, 'userid' => $user1->id]);
         $generator->create_attempt(['h5pactivityid' => $h5p->id, 'userid' => $user2->id]);
 
-        mod_h5pactivity::reset($user1->id, $course, (object)['h5pactivity' => 1, 'archiveh5pactivity' => 1]);
+        mod_h5pactivity::reset($user1->id, $course, (object) ['h5pactivity' => 1, 'archiveh5pactivity' => 1]);
         $this->assertFalse($DB->record_exists('h5pactivity_attempts', ['userid' => $user1->id, 'h5pactivityid' => $h5p->id]));
         $this->assertTrue($DB->record_exists('h5pactivity_attempts', ['userid' => $user2->id, 'h5pactivityid' => $h5p->id]));
 
         $generator->create_attempt(['h5pactivityid' => $h5p->id, 'userid' => $user1->id]);
         $generator->create_attempt(['h5pactivityid' => $h5p->id, 'userid' => $user2->id]);
 
-        mod_h5pactivity::reset($user1->id, $course, (object)['h5pactivity' => 1, 'archiveh5pactivity' => 1]);
+        mod_h5pactivity::reset($user1->id, $course, (object) ['h5pactivity' => 1, 'archiveh5pactivity' => 1]);
         $this->assertFalse($DB->record_exists('h5pactivity_attempts', ['userid' => $user1->id, 'h5pactivityid' => $h5p->id]));
         $this->assertTrue($DB->record_exists('h5pactivity_attempts', ['userid' => $user2->id, 'h5pactivityid' => $h5p->id]));
 
@@ -176,7 +178,7 @@ class mod_h5pactivity_test extends \advanced_testcase {
             $this->assertTrue($DB->record_exists('local_recompletion_h5pr', ['attemptid' => $attempt->id]));
         }
 
-        mod_h5pactivity::reset($user2->id, $course, (object)['h5pactivity' => 1, 'archiveh5pactivity' => 1]);
+        mod_h5pactivity::reset($user2->id, $course, (object) ['h5pactivity' => 1, 'archiveh5pactivity' => 1]);
         $this->assertFalse($DB->record_exists('h5pactivity_attempts', ['userid' => $user1->id, 'h5pactivityid' => $h5p->id]));
         $this->assertFalse($DB->record_exists('h5pactivity_attempts', ['userid' => $user2->id, 'h5pactivityid' => $h5p->id]));
 

--- a/tests/plugins/mod_lesson_test.php
+++ b/tests/plugins/mod_lesson_test.php
@@ -16,6 +16,9 @@
 
 namespace local_recompletion\plugins;
 
+use advanced_testcase;
+use stdClass;
+
 /**
  * Tests for mod_lesson.
  *
@@ -25,17 +28,19 @@ namespace local_recompletion\plugins;
  *
  * @covers \local_recompletion\plugins\mod_lesson
  */
-class mod_lesson_test extends \advanced_testcase {
+class mod_lesson_test extends advanced_testcase {
 
     /**
      * Lesson object.
-     * @var \stdClass
+     *
+     * @var stdClass
      */
     protected $lesson;
 
     /**
      * User object.
-     * @var \stdClass
+     *
+     * @var stdClass
      */
     protected $user;
 
@@ -47,55 +52,55 @@ class mod_lesson_test extends \advanced_testcase {
 
         $generator = $this->getDataGenerator()->get_plugin_generator('mod_lesson');
         $page = $generator->create_question_truefalse($this->lesson);
-        $panswers = $DB->get_records('lesson_answers', array('lessonid' => $this->lesson->id, 'pageid' => $page->id), 'id');
+        $panswers = $DB->get_records('lesson_answers', ['lessonid' => $this->lesson->id, 'pageid' => $page->id], 'id');
         $answerid = reset($panswers)->id;
 
         $newpageattempt = [
-            'lessonid' => $this->lesson->id,
-            'pageid' => $page->id,
-            'userid' => $this->user->id,
-            'answerid' => $answerid,
-            'retry' => 1,
-            'correct' => 1,
-            'useranswer' => '1',
-            'timeseen' => time(),
+                'lessonid' => $this->lesson->id,
+                'pageid' => $page->id,
+                'userid' => $this->user->id,
+                'answerid' => $answerid,
+                'retry' => 1,
+                'correct' => 1,
+                'useranswer' => '1',
+                'timeseen' => time(),
         ];
         $DB->insert_record('lesson_attempts', (object) $newpageattempt);
 
         $newgrade = [
-            'lessonid' => $this->lesson->id,
-            'userid' => $this->user->id,
-            'grade' => 50,
-            'late' => 0,
-            'completed' => time(),
+                'lessonid' => $this->lesson->id,
+                'userid' => $this->user->id,
+                'grade' => 50,
+                'late' => 0,
+                'completed' => time(),
         ];
         $DB->insert_record('lesson_grades', (object) $newgrade);
 
-        $timer = (object)[
-            'lessonid' => $this->lesson->id,
-            'userid' => $this->user->id,
-            'completed' => 1,
-            'starttime' => time(),
-            'lessontime' => time(),
+        $timer = (object) [
+                'lessonid' => $this->lesson->id,
+                'userid' => $this->user->id,
+                'completed' => 1,
+                'starttime' => time(),
+                'lessontime' => time(),
         ];
         $DB->insert_record("lesson_timer", $timer);
 
-        $branch = (object)[
-            'lessonid' => $this->lesson->id,
-            'userid' => $this->user->id,
-            'pageid' => $page->id,
-            'retry' => 1,
-            'flag' => 0,
-            'timeseen' => time(),
+        $branch = (object) [
+                'lessonid' => $this->lesson->id,
+                'userid' => $this->user->id,
+                'pageid' => $page->id,
+                'retry' => 1,
+                'flag' => 0,
+                'timeseen' => time(),
         ];
         $DB->insert_record("lesson_branch", $branch);
 
-        $useroverride = (object)[
-            'lessonid' => $this->lesson->id,
-            'userid' => $this->user->id,
-            'sortorder' => 1,
-            'available' => 100,
-            'deadline' => 200
+        $useroverride = (object) [
+                'lessonid' => $this->lesson->id,
+                'userid' => $this->user->id,
+                'sortorder' => 1,
+                'available' => 100,
+                'deadline' => 200,
         ];
         $DB->insert_record('lesson_overrides', $useroverride);
     }
@@ -122,11 +127,11 @@ class mod_lesson_test extends \advanced_testcase {
         $this->attempt_lesson();
 
         $tables = [
-            'lesson_attempts' => 'local_recompletion_la',
-            'lesson_grades' => 'local_recompletion_lg',
-            'lesson_timer' => 'local_recompletion_lt',
-            'lesson_branch' => 'local_recompletion_lb',
-            'lesson_overrides' => 'local_recompletion_lo',
+                'lesson_attempts' => 'local_recompletion_la',
+                'lesson_grades' => 'local_recompletion_lg',
+                'lesson_timer' => 'local_recompletion_lt',
+                'lesson_branch' => 'local_recompletion_lb',
+                'lesson_overrides' => 'local_recompletion_lo',
         ];
 
         foreach ($tables as $originaltable => $archivetable) {
@@ -134,20 +139,20 @@ class mod_lesson_test extends \advanced_testcase {
             $this->assertFalse($DB->record_exists($archivetable, ['userid' => $this->user->id, 'lessonid' => $this->lesson->id]));
         }
 
-        mod_lesson::reset($this->user->id, $course, (object)['lesson' => 0, 'archivelesson' => 0]);
+        mod_lesson::reset($this->user->id, $course, (object) ['lesson' => 0, 'archivelesson' => 0]);
         $this->assertTrue($DB->record_exists($originaltable, ['userid' => $this->user->id, 'lessonid' => $this->lesson->id]));
         $this->assertFalse($DB->record_exists($archivetable, ['userid' => $this->user->id, 'lessonid' => $this->lesson->id]));
 
-        mod_lesson::reset($this->user->id, $course, (object)['lesson' => 0, 'archivelesson' => 1]);
+        mod_lesson::reset($this->user->id, $course, (object) ['lesson' => 0, 'archivelesson' => 1]);
         $this->assertTrue($DB->record_exists($originaltable, ['userid' => $this->user->id, 'lessonid' => $this->lesson->id]));
         $this->assertFalse($DB->record_exists($archivetable, ['userid' => $this->user->id, 'lessonid' => $this->lesson->id]));
 
-        mod_lesson::reset($this->user->id, $course, (object)['lesson' => 1, 'archivelesson' => 0]);
+        mod_lesson::reset($this->user->id, $course, (object) ['lesson' => 1, 'archivelesson' => 0]);
         $this->assertFalse($DB->record_exists($originaltable, ['userid' => $this->user->id, 'lessonid' => $this->lesson->id]));
         $this->assertFalse($DB->record_exists($archivetable, ['userid' => $this->user->id, 'lessonid' => $this->lesson->id]));
 
         $this->attempt_lesson();
-        mod_lesson::reset($this->user->id, $course, (object)['lesson' => 1, 'archivelesson' => 1]);
+        mod_lesson::reset($this->user->id, $course, (object) ['lesson' => 1, 'archivelesson' => 1]);
         $this->assertFalse($DB->record_exists($originaltable, ['userid' => $this->user->id, 'lessonid' => $this->lesson->id]));
         $this->assertTrue($DB->record_exists($archivetable, ['userid' => $this->user->id, 'lessonid' => $this->lesson->id]));
     }

--- a/tests/schedule_test.php
+++ b/tests/schedule_test.php
@@ -16,6 +16,10 @@
 
 namespace local_recompletion;
 
+use advanced_testcase;
+use local_recompletion_recompletion_form;
+use function local_recompletion_calculate_schedule_time;
+
 /**
  * Class schedule_test.
  *
@@ -24,41 +28,41 @@ namespace local_recompletion;
  * @copyright  Catalyst IT, 2023
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class schedule_test extends \advanced_testcase {
+class schedule_test extends advanced_testcase {
 
     /**
      * Basic test for future time scheduling.
      */
     public function test_local_recompletion() {
         global $CFG;
-        require_once($CFG->dirroot.'/local/recompletion/locallib.php');
+        require_once($CFG->dirroot . '/local/recompletion/locallib.php');
 
         $now = time();
 
         // Ensure the past cannot be set.
-        $nextresettime = \local_recompletion_calculate_schedule_time('yesterday');
+        $nextresettime = local_recompletion_calculate_schedule_time('yesterday');
         $this->assertEquals(0, $nextresettime);
 
         // Ensure tomorrow is valid.
-        $nextresettime = \local_recompletion_calculate_schedule_time('tomorrow');
+        $nextresettime = local_recompletion_calculate_schedule_time('tomorrow');
         $this->assertGreaterThan($now, $nextresettime);
 
         // Ensure the past (with a year) cannot be set.
-        $nextresettime = \local_recompletion_calculate_schedule_time('Dec 31 2020');
+        $nextresettime = local_recompletion_calculate_schedule_time('Dec 31 2020');
         $this->assertEquals(0, $nextresettime);
 
         // Ensure no year dates, are okay.
-        $nextresettime = \local_recompletion_calculate_schedule_time('Jan 1');
+        $nextresettime = local_recompletion_calculate_schedule_time('Jan 1');
         $this->assertGreaterThan($now, $nextresettime);
 
         // Same as previously, but for any time of the year.
-        $nextresettime = \local_recompletion_calculate_schedule_time('Dec 31');
+        $nextresettime = local_recompletion_calculate_schedule_time('Dec 31');
         $this->assertGreaterThan($now, $nextresettime);
 
         // Ensure the time, not just a date, can also be used.
         $str = 'Dec 31 14:50';
         $format = 'M d H:i';
-        $nextresettime = \local_recompletion_calculate_schedule_time($str);
+        $nextresettime = local_recompletion_calculate_schedule_time($str);
         $formatteddate = date($format, $nextresettime);
         $this->assertEquals($formatteddate, $str);
     }
@@ -67,20 +71,20 @@ class schedule_test extends \advanced_testcase {
      * Basic test for local_recompletion_recompletion_form::validation.
      *
      * @dataProvider recompletion_form_validation_provider
-     * @covers \local_recompletion_recompletion_form::validation
+     * @covers       \local_recompletion_recompletion_form::validation
      *
      * @param array $data the form data to mock submit
      * @param bool $valid if this form data is valid
      */
-    public function test_recompletion_form_validation(array $data, bool $valid) {
+    public function test_recompletion_form_validation(array $data, bool $valid): void {
         $this->resetAfterTest(true);
 
         $course = $this->getDataGenerator()->create_course();
 
         // Mock submit and get form data.
-        \local_recompletion_recompletion_form::mock_submit($data);
+        local_recompletion_recompletion_form::mock_submit($data);
         $customdata = ['course' => $course];
-        $form = new \local_recompletion_recompletion_form('recompletion.php?id=' . $course->id, $customdata);
+        $form = new local_recompletion_recompletion_form('recompletion.php?id=' . $course->id, $customdata);
         $formdata = $form->get_data();
 
         // Test for valid or invalid form data.
@@ -100,53 +104,53 @@ class schedule_test extends \advanced_testcase {
      */
     public static function recompletion_form_validation_provider(): array {
         return [
-            'Valid recompletionschedule, no recompletionschedulestart' => [
-                'data' => [
-                    'recompletionschedule' => '3 months',
+                'Valid recompletionschedule, no recompletionschedulestart' => [
+                        'data' => [
+                                'recompletionschedule' => '3 months',
+                        ],
+                        'valid' => true,
                 ],
-                'valid' => true,
-            ],
-            'Invalid recompletionschedule, no recompletionschedulestart' => [
-                'data' => [
-                    'recompletionschedule' => 'Invalid date string',
+                'Invalid recompletionschedule, no recompletionschedulestart' => [
+                        'data' => [
+                                'recompletionschedule' => 'Invalid date string',
+                        ],
+                        'valid' => false,
                 ],
-                'valid' => false,
-            ],
-            'Valid recompletionschedule, valid recompletionschedulestart of today' => [
-                'data' => [
-                    'recompletionschedule' => '3 months',
-                    'recompletionschedulestart' => strtotime('today'),
+                'Valid recompletionschedule, valid recompletionschedulestart of today' => [
+                        'data' => [
+                                'recompletionschedule' => '3 months',
+                                'recompletionschedulestart' => strtotime('today'),
+                        ],
+                        'valid' => true,
                 ],
-                'valid' => true,
-            ],
-            'Valid recompletionschedule, valid recompletionschedulestart of tomorrow' => [
-                'data' => [
-                    'recompletionschedule' => '3 months',
-                    'recompletionschedulestart' => strtotime('tomorrow'),
+                'Valid recompletionschedule, valid recompletionschedulestart of tomorrow' => [
+                        'data' => [
+                                'recompletionschedule' => '3 months',
+                                'recompletionschedulestart' => strtotime('tomorrow'),
+                        ],
+                        'valid' => true,
                 ],
-                'valid' => true,
-            ],
-            'Invalid recompletionschedule, invalid recompletionschedulestart' => [
-                'data' => [
-                    'recompletionschedule' => 'Invalid date string',
-                    'recompletionschedulestart' => strtotime('yesterday'),
+                'Invalid recompletionschedule, invalid recompletionschedulestart' => [
+                        'data' => [
+                                'recompletionschedule' => 'Invalid date string',
+                                'recompletionschedulestart' => strtotime('yesterday'),
+                        ],
+                        'valid' => false,
                 ],
-                'valid' => false,
-            ],
-            'Valid recompletionschedule, invalid recompletionschedulestart' => [
-                'data' => [
-                    'recompletionschedule' => '3 months',
-                    'recompletionschedulestart' => strtotime('yesterday'),
+                'Valid recompletionschedule, invalid recompletionschedulestart' => [
+                        'data' => [
+                                'recompletionschedule' => '3 months',
+                                'recompletionschedulestart' => strtotime('yesterday'),
+                        ],
+                        'valid' => false,
                 ],
-                'valid' => false,
-            ],
-            'Invalid recompletionschedule, valid recompletionschedulestart' => [
-                'data' => [
-                    'recompletionschedule' => 'Invalid date string',
-                    'recompletionschedulestart' => strtotime('today'),
+                'Invalid recompletionschedule, valid recompletionschedulestart' => [
+                        'data' => [
+                                'recompletionschedule' => 'Invalid date string',
+                                'recompletionschedulestart' => strtotime('today'),
+                        ],
+                        'valid' => false,
                 ],
-                'valid' => false,
-            ],
         ];
     }
 }

--- a/version.php
+++ b/version.php
@@ -24,9 +24,9 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2025041400;
-$plugin->release   = 2025041400;
-$plugin->maturity  = MATURITY_STABLE;
-$plugin->requires  = 2024100700; // Requires 4.5.
+$plugin->version = 2025041400;
+$plugin->release = 2025041400;
+$plugin->maturity = MATURITY_STABLE;
+$plugin->requires = 2024100700; // Requires 4.5.
 $plugin->component = 'local_recompletion';
 $plugin->supported = [405, 500];


### PR DESCRIPTION
This pull request updates the custom reports entities to use the get_default_tables() method instead of the deprecated get_default_table_aliases(), ensuring compatibility with Moodle 4.5.

Fixes issue #209 where generating custom reports triggered a deprecation warning in Moodle 4.5.