### PR TITLE
Fixes #213. Use core\clock in time calculations and tests.

### DIFF
--- a/classes/recompletion_form.php
+++ b/classes/recompletion_form.php
@@ -13,6 +13,8 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+use core\clock;
+use core\di;
 
 /**
  * Course recompletion settings form.
@@ -192,6 +194,8 @@ class local_recompletion_recompletion_form extends moodleform {
     public function validation($data, $files): array {
         $errors = [];
 
+        $clock = di::get(clock::class);
+
         // Validate 'recompletionschedule' field.
         if (!empty($data['recompletionschedule'])) {
             // Check if the input is compatible with strtotime().
@@ -203,7 +207,7 @@ class local_recompletion_recompletion_form extends moodleform {
 
         // Validate 'recompletionschedulestart' field.
         if (!empty($data['recompletionschedulestart'])) {
-            $today = strtotime(date('Y-m-d'));
+            $today = $clock->now()->modify('midnight')->getTimestamp();
             if ($data['recompletionschedulestart'] < $today) {
                 $errors['recompletionschedulestart'] = get_string('invalidschedulestartdate', 'local_recompletion');
             }

--- a/locallib.php
+++ b/locallib.php
@@ -23,6 +23,9 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use core\clock;
+use core\di;
+
 defined('MOODLE_INTERNAL') || die();
 
 // Used by settings to decide if attempts should be deleted or an extra attempt allowed.
@@ -192,21 +195,24 @@ function local_recompletion_get_config($course) {
  * @return int a future timestamp, or 0.
  */
 function local_recompletion_calculate_schedule_time(string $input): int {
+
+    $clock = di::get(clock::class);
+
     // Special handling for next reset time.
     // Assumptions. If this is in the past, try and append a year stamp for
     // next year. If that doesnt evaluate, we cannot deal with this.
-    $time = strtotime($input);
+    $time = strtotime($input, $clock->time());
     if ($time === false) {
         // We cannot handle this value.
         return 0;
     }
-    if ($time < time()) {
+    if ($time < $clock->time()) {
         // Try with a year appended to force a future calculation.
-        $schedulestring = $input . ' ' . date('Y', strtotime('+1 year'));
-        $time = strtotime($schedulestring);
+        $schedulestring = $input . ' ' . date('Y', strtotime('+1 year', $clock->time()));
+        $time = strtotime($schedulestring, $clock->time());
 
         // If this isn't valid or still in the past (somehow), we can't trust it.
-        if ($time === false || $time < time()) {
+        if ($time === false || $time < $clock->time()) {
             return 0;
         }
 

--- a/tests/schedule_test.php
+++ b/tests/schedule_test.php
@@ -16,6 +16,9 @@
 
 namespace local_recompletion;
 
+use core\clock;
+use core\di;
+
 /**
  * Class schedule_test.
  *
@@ -33,7 +36,8 @@ class schedule_test extends \advanced_testcase {
         global $CFG;
         require_once($CFG->dirroot.'/local/recompletion/locallib.php');
 
-        $now = time();
+        $this->mock_clock_with_frozen();
+        $clock = di::get(clock::class);
 
         // Ensure the past cannot be set.
         $nextresettime = \local_recompletion_calculate_schedule_time('yesterday');
@@ -41,7 +45,7 @@ class schedule_test extends \advanced_testcase {
 
         // Ensure tomorrow is valid.
         $nextresettime = \local_recompletion_calculate_schedule_time('tomorrow');
-        $this->assertGreaterThan($now, $nextresettime);
+        $this->assertGreaterThan($clock->time(), $nextresettime);
 
         // Ensure the past (with a year) cannot be set.
         $nextresettime = \local_recompletion_calculate_schedule_time('Dec 31 2020');
@@ -49,11 +53,11 @@ class schedule_test extends \advanced_testcase {
 
         // Ensure no year dates, are okay.
         $nextresettime = \local_recompletion_calculate_schedule_time('Jan 1');
-        $this->assertGreaterThan($now, $nextresettime);
+        $this->assertGreaterThan($clock->time(), $nextresettime);
 
         // Same as previously, but for any time of the year.
         $nextresettime = \local_recompletion_calculate_schedule_time('Dec 31');
-        $this->assertGreaterThan($now, $nextresettime);
+        $this->assertGreaterThan($clock->time(), $nextresettime);
 
         // Ensure the time, not just a date, can also be used.
         $str = 'Dec 31 14:50';
@@ -99,6 +103,7 @@ class schedule_test extends \advanced_testcase {
      * @return array
      */
     public static function recompletion_form_validation_provider(): array {
+        $clock = di::get(clock::class);
         return [
             'Valid recompletionschedule, no recompletionschedulestart' => [
                 'data' => [
@@ -115,35 +120,35 @@ class schedule_test extends \advanced_testcase {
             'Valid recompletionschedule, valid recompletionschedulestart of today' => [
                 'data' => [
                     'recompletionschedule' => '3 months',
-                    'recompletionschedulestart' => strtotime('today'),
+                    'recompletionschedulestart' => $clock->now()->modify('today')->getTimestamp(),
                 ],
                 'valid' => true,
             ],
             'Valid recompletionschedule, valid recompletionschedulestart of tomorrow' => [
                 'data' => [
                     'recompletionschedule' => '3 months',
-                    'recompletionschedulestart' => strtotime('tomorrow'),
+                    'recompletionschedulestart' => $clock->now()->modify('tomorrow')->getTimestamp(),
                 ],
                 'valid' => true,
             ],
             'Invalid recompletionschedule, invalid recompletionschedulestart' => [
                 'data' => [
                     'recompletionschedule' => 'Invalid date string',
-                    'recompletionschedulestart' => strtotime('yesterday'),
+                    'recompletionschedulestart' => $clock->now()->modify('yesterday')->getTimestamp(),
                 ],
                 'valid' => false,
             ],
             'Valid recompletionschedule, invalid recompletionschedulestart' => [
                 'data' => [
                     'recompletionschedule' => '3 months',
-                    'recompletionschedulestart' => strtotime('yesterday'),
+                    'recompletionschedulestart' => $clock->now()->modify('yesterday')->getTimestamp()
                 ],
                 'valid' => false,
             ],
             'Invalid recompletionschedule, valid recompletionschedulestart' => [
                 'data' => [
                     'recompletionschedule' => 'Invalid date string',
-                    'recompletionschedulestart' => strtotime('today'),
+                    'recompletionschedulestart' => $clock->now()->modify('today')->getTimestamp(),
                 ],
                 'valid' => false,
             ],


### PR DESCRIPTION
This patch changes the date time calculations to use the Moodle Time API and sets the unit tests to use a frozen clock implementation so that issues like #213 shouldn't occur.