### PR TITLE
[#216] Fix phpunit deprecation

### DIFF
--- a/tests/local/restrictions/enrol_test.php
+++ b/tests/local/restrictions/enrol_test.php
@@ -35,7 +35,7 @@ class enrol_test extends \advanced_testcase {
         $data = new stdClass();
 
         enrol::set_form_data($data);
-        $this->assertObjectNotHasAttribute('restrictenrol', $data);
+        $this->assertObjectNotHasProperty('restrictenrol', $data);
     }
 
     /**


### PR DESCRIPTION
Closes #216 

According to this issue https://github.com/sebastianbergmann/phpunit/issues/5478 the functions are equivalent so there are no further changes necessary