### PR TITLE
Fix unit test failure: The data provider specified is invalid

### DIFF
--- a/tests/local/restrictions/enrol_test.php
+++ b/tests/local/restrictions/enrol_test.php
@@ -43,7 +43,7 @@ class enrol_test extends \advanced_testcase {
      *
      * @return array
      */
-    public function set_form_data_data_provider(): array {
+    public static function set_form_data_data_provider(): array {
         return [
             ['', ''],
             [1, 1],


### PR DESCRIPTION
This fixes

There was 1 PHPUnit error:

1) local_recompletion\local\restrictions\enrol_test::test_set_form_data
The data provider specified for local_recompletion\local\restrictions\enrol_test::test_set_form_data is invalid
Data Provider method local_recompletion\local\restrictions\enrol_test::set_form_data_data_provider() is not static

/var/www/html/local/recompletion/tests/local/restrictions/enrol_test.php:65
