### PR TITLE
bugfix: fix mssql syntax / db id collision

### DIFF
--- a/classes/plugins/mod_h5pactivity.php
+++ b/classes/plugins/mod_h5pactivity.php
@@ -129,40 +129,41 @@ class mod_h5pactivity {
                     $attemptids = array_keys($attempts);
 
                     foreach ($attempts as $attempt) {
+                        // Store some extra metadata about the attempts.
                         $attempt->course = $course->id;
                         $attempt->originalattemptid = $attempt->id;
                     }
 
+                    // Store these as-is into the recompletion h5p attempts storage (with extra metadata per above).
                     $DB->insert_records('local_recompletion_h5p', $attempts);
+
+                    // Map the source attempt IDs to the archive IDs from this reset only.
+                    [$insql, $inparams] = $DB->get_in_or_equal($attemptids, SQL_PARAMS_NAMED);
+                    $archivedattempts = $DB->get_records_select(
+                        'local_recompletion_h5p',
+                        "originalattemptid $insql",
+                        $inparams,
+                        '',
+                        'id, originalattemptid'
+                    );
+                    $archivedattemptids = [];
+                    foreach ($archivedattempts as $archivedattempt) {
+                        $archivedattemptids[$archivedattempt->originalattemptid] = $archivedattempt->id;
+                    }
 
                     // Archive results.
                     $results = $DB->get_records_select('h5pactivity_attempts_results', $resultsselectsql, $params);
                     if (!empty($results)) {
                         foreach ($results as $result) {
                             $result->course = $course->id;
+                            $result->attemptid = $archivedattemptids[$result->attemptid];
                         }
                         $DB->insert_records('local_recompletion_h5pr', $results);
-
-                        // Update attemptid for just inserted attempt results with IDs of previously inserted attempts.
-                        // We use temp originalattemptid here as it should be unique.
-                        if ($DB->get_dbfamily() == 'mysql') {
-                            $sql = 'UPDATE {local_recompletion_h5pr} h5pr
-                                      JOIN {local_recompletion_h5p} h5p ON h5pr.attemptid = h5p.originalattemptid
-                                       SET h5pr.attemptid = h5p.id';
-                        } else {
-                            $sql = ' UPDATE {local_recompletion_h5pr} h5pr
-                                        SET attemptid = h5p.id
-                                       FROM {local_recompletion_h5p} h5p
-                                      WHERE h5pr.attemptid = h5p.originalattemptid';
-                        }
-
-                        $DB->execute($sql);
                     }
 
                     // Now reset originalattemptid as we don't need it anymore.
                     // As well as to avoid issues with backup and restore when potentially originalattemptid can clash
                     // if restoring a course from another Moodle instance.
-                    [$insql, $inparams] = $DB->get_in_or_equal($attemptids, SQL_PARAMS_NAMED);
                     $sql = "UPDATE {local_recompletion_h5p} SET originalattemptid = 0 WHERE originalattemptid $insql";
                     $DB->execute($sql, $inparams);
                 }

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2026022705;
-$plugin->release   = 2026022705;
+$plugin->version   = 2026022706;
+$plugin->release   = 2026022706;
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->requires  = 2024100700; // Requires 4.5.
 $plugin->component = 'local_recompletion';


### PR DESCRIPTION
This originally came to my attention because MSSQL does not support table aliasing that this query was doing previously, so the tests for the h5pactivity in this plugin were failing, however, after I fixed the table aliasing another test would fail but only in MSSQL.

This then turned out to be a pre-existing DB id collision issue that just never happened in pgsql/mariadb unit tests.

## Context
The code in question does the following:
- Gets h5pactivity_attempts
- Stores these into recompletion h5p attempts table
- Looks up the ids of the new attempts (i.e. getting the old id vs new id)
- Updates the h5p attempt results
- Copies them, updating the old attempt reference to the new attempt reference.

## Bug
This was being done in a single SQL query - a Update + select
```sql
UPDATE {local_recompletion_h5pr} h5pr
JOIN {local_recompletion_h5p} h5p ON h5pr.attemptid = h5p.originalattemptid
SET h5pr.attemptid = h5p.id
```
The issue is that the archived result attemptid may _have already been converted_ to the new archived attemptid in a previous run.

Pgsql & Mariadb must just have never had overlapping ids, so this issue never occurred during testing. But MSSQL does and so exhibits the issue.

## Fix
Instead of doing it in one db query, we manually query the records we just archived, get their new ids, and then use that to map. This ensures only the actual records are targeted.

In terms of scale, given this function already queries all the attempts into memory (line 127) I don't think there is any change in the scalability.